### PR TITLE
New markdown versions for CFR and FR XML user guides

### DIFF
--- a/Bills-Summary-XML-User-Guide.md
+++ b/Bills-Summary-XML-User-Guide.md
@@ -175,7 +175,7 @@ The following conventions are used in this document:
   abbreviations that can be found in bill summaries are hr, hjres, hconres, 
   hres, s, sconres, sres, and sjres.
  
-  See [Section 1.1](1.1-Types-of-Bill-Summaries)  of this document for a description of each measure type. 
+  See Section 1.1 of this document for a description of each measure type. 
 
 - `@measure-number` 
 
@@ -194,7 +194,7 @@ The following conventions are used in this document:
   The measure type abbreviations that can be found in bill summaries are 
   hr, hjres, hconres, hres, s, sconres, sres, and sjres.
  
-  See [Section 1.1](1.1-Types-of-Bill-Summaries) of this document for a description of each measure type. 
+  See Section 1.1 of this document for a description of each measure type. 
 
 - `@originChamber` 
 

--- a/CFR-XML_User-Guide.md
+++ b/CFR-XML_User-Guide.md
@@ -17,13 +17,13 @@ U.S. Government Publishing Office
 
 The U.S. Government Publishing Office (GPO) and the National Archives' Office of the Federal Register (OFR) partnership is offering bulk data downloads of Code of Federal Regulations (CFR) files to the general public via Data.gov and FDsys. This effort began when the President challenged Federal agencies to create a more open and transparent government, promote accountability, and provide information to citizens about what their Government is doing (see [74 FR 4685, January 26, 2009](http://www.gpo.gov/fdsys/pkg/FR-2009-01-26/pdf/E9-1777.pdf)).
 
-The [Public Printer's letter of March 9, 2009](http://www.gpo.gov/pdfs/news-media/letter\_030909.pdf) pledged to provide trusted information in whatever form is required to meet the President's objectives &nbsp;
+The [Public Printer's letter of March 9, 2009](http://www.gpo.gov/pdfs/news-media/letter\_030909.pdf) pledged to provide trusted information in whatever form is required to meet the President's objectives. &nbsp;
 
 In addition, the Office of the Federal Register coordinates with the Office of Science Technology Policy to ensure that the OFR/GPO partnership meets customer expectations. To follow through on our commitment, we are expanding and accelerating the development of FDsys to provide XML-structured content as rendered output. &nbsp;This will give users access to masses of data to reconfigure and redistribute as they wish to meet the specialized needs of their constituencies.
 
 ##1.1.Purpose
 
-The purpose of this document is to provide an overview of Code of Federal Regulations XML files and associated schema. The FDsys Bulk Data repository at http://www.gpo.gov/fdsys/bulkdata/](http://www.gpo.gov/fdsys/bulkdata/) contains the Code of Federal Regulations in XML from 2007 to the present and additional years will be added as they become available. Please see FDsys at [www.fdsys.gov](http://www.fdsys.gov/) for access to the Code of Federal Regulations in PDF and HTML formats. &nbsp;
+The purpose of this document is to provide an overview of Code of Federal Regulations XML files and associated schema. The FDsys Bulk Data repository at http://www.gpo.gov/fdsys/bulkdata/ contains the Code of Federal Regulations in XML from 2007 to the present and additional years will be added as they become available. Please see FDsys at [www.fdsys.gov](http://www.fdsys.gov/) for access to the Code of Federal Regulations in PDF and HTML formats. &nbsp;
 
 ##1.2.Legal Status & Authenticity of Code of Federal Regulations files via Data.gov
 

--- a/CFR-XML_User-Guide.md
+++ b/CFR-XML_User-Guide.md
@@ -13,7 +13,7 @@ U.S. Government Publishing Office
 - 1.1 March 2015
   Markdown version
 
-#1 Introduction
+#1.Introduction
 
 The U.S. Government Publishing Office (GPO) and the National Archives' Office of the Federal Register (OFR) partnership is offering bulk data downloads of Code of Federal Regulations (CFR) files to the general public via Data.gov and FDsys. This effort began when the President challenged Federal agencies to create a more open and transparent government, promote accountability, and provide information to citizens about what their Government is doing (see [74 FR 4685, January 26, 2009](http://www.gpo.gov/fdsys/pkg/FR-2009-01-26/pdf/E9-1777.pdf)).
 
@@ -533,39 +533,28 @@ The ALPHLIST tag contains list of agencies appearing in the Code of Federal Regu
 
 An abbreviated example of the ALPHLIST section and structure is below:
 
-&nbsp;
+ 
 
 ```<CFRDOC>
-
-&nbsp; .
-
-&nbsp; .
-
-&nbsp; .
-
-&nbsp; <ALPHLIST>  
- &nbsp; &nbsp;<HD SOURCE="HED">Alphabetical List of Agencies Appearing in the...</HD>  
- &nbsp; &nbsp;<REV>(Revised as of January 1, 2009)</REV>  
- &nbsp; &nbsp;<AGHD>Agency</AGHD>  
- &nbsp; &nbsp;<CFRHD>CFR Title, Subtitle or Chapter</CFRHD>  
- &nbsp; &nbsp;<AGENCY>Administrative Committee of the Federal Regulations</AGENCY>  
- &nbsp; &nbsp;<CFRID>1, I</CFRID>  
- &nbsp; &nbsp;<AGENCY>Advanced Research Projects Agency</AGENCY>  
- &nbsp; &nbsp;<CFRID>32, I</CFRID>
-
-&nbsp; &nbsp; .
-
-&nbsp; &nbsp; .
-
-&nbsp; &nbsp; .  
- &nbsp;</ALPHLIST>
-
-&nbsp; .
-
-&nbsp; .
-
-&nbsp; .
-
+  .
+  .
+  .
+  <ALPHLIST>  
+    <HD SOURCE="HED">Alphabetical List of Agencies Appearing in the...</HD>  
+    <REV>(Revised as of January 1, 2009)</REV>  
+    <AGHD>Agency</AGHD>  
+    <CFRHD>CFR Title, Subtitle or Chapter</CFRHD>  
+    <AGENCY>Administrative Committee of the Federal Regulations</AGENCY>  
+    <CFRID>1, I</CFRID>  
+    <AGENCY>Advanced Research Projects Agency</AGENCY>  
+    <CFRID>32, I</CFRID>
+    .
+    .
+    .  
+  </ALPHLIST>
+  .
+  .
+  .
 </CFRDOC>```
 
 &nbsp;

--- a/CFR-XML_User-Guide.md
+++ b/CFR-XML_User-Guide.md
@@ -322,7 +322,8 @@ The abbreviated example of the TITLE, CHAPTER, PART and SUBPART tags are shown b
   .
   .
   .
-</CFRDOC>```
+</CFRDOC>
+```
 
 &nbsp;
 
@@ -515,7 +516,8 @@ An abbreviated example of the CHAPTER section and structure is below:
  .
  .
 
-</CFRDOC>```
+</CFRDOC>
+```
 
 &nbsp;
 

--- a/CFR-XML_User-Guide.md
+++ b/CFR-XML_User-Guide.md
@@ -1,0 +1,575 @@
+#Federal Digital System (FDsys) User Guide
+  
+##Code of Federal Regulations XML Rendition 
+
+Prepared by:Office of Programs, Strategy, and Technology
+
+Office of the Chief Technology Officer  
+U.S. Government Publishing Office
+
+##Revision
+- 1.0 December 2009
+  Initial publication
+- 1.1 March 2015
+  Markdown version
+
+#1 Introduction
+
+The U.S. Government Publishing Office (GPO) and the National Archives' Office of the Federal Register (OFR) partnership is offering bulk data downloads of Code of Federal Regulations (CFR) files to the general public via Data.gov and FDsys. This effort began when the President challenged Federal agencies to create a more open and transparent government, promote accountability, and provide information to citizens about what their Government is doing (see [74 FR 4685, January 26, 2009](http://www.gpo.gov/fdsys/pkg/FR-2009-01-26/pdf/E9-1777.pdf)).
+
+The [Public Printer's letter of March 9, 2009](http://www.gpo.gov/pdfs/news-media/letter\_030909.pdf) pledged to provide trusted information in whatever form is required to meet the President's objectives &nbsp;
+
+In addition, the Office of the Federal Register coordinates with the Office of Science Technology Policy to ensure that the OFR/GPO partnership meets customer expectations. To follow through on our commitment, we are expanding and accelerating the development of FDsys to provide XML-structured content as rendered output. &nbsp;This will give users access to masses of data to reconfigure and redistribute as they wish to meet the specialized needs of their constituencies.
+
+##1.1.Purpose
+
+The purpose of this document is to provide an overview of Code of Federal Regulations XML files and associated schema. The FDsys Bulk Data repository at http://www.gpo.gov/fdsys/bulkdata/](http://www.gpo.gov/fdsys/bulkdata/) contains the Code of Federal Regulations in XML from 2007 to the present and additional years will be added as they become available. Please see FDsys at [www.fdsys.gov](http://www.fdsys.gov/) for access to the Code of Federal Regulations in PDF and HTML formats. &nbsp;
+
+##1.2.Legal Status & Authenticity of Code of Federal Regulations files via Data.gov
+
+&nbsp;
+
+**Q. What is the data set available for the Code of Federal Regulations in XML?**
+
+**A. ** Code of Federal Regulations files in XML have been converted and simplified from the SGML rendition used for the printed publication. The Code of Federal Regulations is available in XML starting with the year 2000, when GPO began composing the Code of Federal Regulations in SGML. OFR/GPO plan to convert the remaining electronic data set at a future date.
+
+&nbsp;
+
+**Q. &nbsp;Are bulk data downloads of XML files offered on FDsys via Data.gov and FDsys part of the official version of the Code of Federal Regulations?**
+
+**A.** No, the XML-structured files offered for bulk download are not part of the official on-line format of the _Code of Federal Regulations_. While GPO's XML files are based on the original source data submitted by Federal agencies, OFR markup, and GPO typesetting and composition markup in SGML, only the PDF and Text versions of _Code of Federal Regulations_content on GPO Access and FDsys have legal status as parts of the official online format of the _Code of Federal Regulations_. &nbsp;Additional development will be required before OFR/GPO can specify that XML files are a part of the official online edition of the _Code of Federal Regulations_. &nbsp;
+
+&nbsp;
+
+**Q. Do OFR/GPO plan to include XML files as part of the official format of the Code of Federal Regulations?**
+
+**A.** Yes. The current set of XML-structured material (minus graphics) is not yet characterized as part of the official online _Code of Federal Regulations_ format because the underlying data used to create a viewable rendition of the material must be thoroughly scrutinized and tested. The XML-structured files are derived from SGML-tagged data and printing codes, which may produce anomalies in display. &nbsp;For example, complex tabular material in XML files may not display as correctly composed objects equivalent to the tables that appear in the Text and PDF files. &nbsp;Tabular material that displays in an ambiguous or distorted manner could affect the substantive meaning of regulations and other documents.
+Our goal is to clean up the XML data and develop associated style sheets to the point that the XML rendition can be characterized as a display format of the official online edition. We are also developing the means to embed graphics in the files, so that an XML version may be deemed both official and complete. The OFR will issue a _Federal Register Bulletin_ to alert users when the XML-structured files are ready to be included as part of the official online edition. 
+
+&nbsp;
+
+**Q. &nbsp;What is the legal basis for making determinations about official status?**
+
+**A.** The Federal Register Act established the Administrative Committee of the Federal Register (Administrative Committee or ACFR) as the regulatory body with authority to determine the format(s) of its official publications, including the Code of Federal Regulations(44 U.S.C. Ch. 15). Under 1 CFR 8.6(a), the official formats approved by the ACFR include a paper edition, a microfiche edition, and an online edition. OFR and GPO carry out ACFR regulations by developing appropriate means to display _Code of Federal Regulations_ material in the official formats.
+
+&nbsp;
+
+**Q. When did the Code of Federal Regulations first appear online?**
+
+**A.** The first official volumes were published online in 1996. The first full online edition dates to 1997 as authorized by resolution of the Administrative Committee and its regulations at 1 CFR 8.6, and by Public Law 103-40 (the Government Printing Office Electronic Information Enhancement Act of 1993; codified at 44 U.S.C. 4101).
+
+&nbsp;
+
+**Q. &nbsp;Are Code of Federal Regulations XML bulk download files digitally signed?**
+
+**A.** No, XML files available for download are not digitally signed. They can be manipulated and enriched to operate in the various applications that users may devise. GPO is evaluating technology that could be used to digitally sign XML files for future official editions posted on FDsys.  Adding signed non-PDF files to FDsys would be an enhancement for FDsys users, but would not be used to restrict or adversely affect the XML bulk data downloads available to our customers. 
+
+&nbsp;
+
+**Q. &nbsp;What does the term "digitally signed" mean?**
+
+**A.** Currently, GPO uses digital signature technology on PDF documents to add a visible Seal of Authenticity (a graphic of an eagle) to authenticated and certified documents. The technology allows GPO to secure data integrity, and provide users with assurance that the content is unchanged since it was disseminated by GPO. A signed and certified document also displays a blue ribbon icon to the left of the Seal of Authenticity and in the Signatures tab within Adobe Acrobat or Reader. When users print a document that has been signed and certified by GPO, the Seal of Authenticity will automatically print on the document, but the blue ribbon will not print.
+
+&nbsp;
+
+**Q. How reliable is the metadata and the underlying tagging in bulk data files?**
+
+**A.** The document markup and metadata found within bulk data files are generally reliable and complete.  However, there are variations in this underlying data due to inconsistencies in the composition and typesetting process. As a result, some data-mining applications and user aids may not produce 100 per cent accurate results. 
+
+&nbsp;
+**Q. What is the legal status of Code of Federal Regulations user aids?**
+
+**A.** Code of Federal Regulations user aids, including, finding aids, indexes, search tools, metadata associations, and tagging schemes are not part of the legal text of the _Code of Federal Regulations_. These ancillary features help users explore and extract data, but the official legal text stands on its own. No person should form absolute legal conclusions based on search results, finding aids, metadata associations, extractions of data, and the like. Ultimately, only the official text of the _Code of Federal Regulations_ may be relied upon as evidence in a court of law. 
+
+**Q. What is the authenticity of Code of Federal Regulations bulk data files after they have been downloaded to another site? &nbsp;**
+
+**A.**  We cannot vouch for the authenticity of data that is not under OFR/GPO control. OFR and GPO are providing free access to Code of Federal Regulations data via XML for display in various applications and mash-ups outside the FDsys domain. The OFR/GPO partnership does not endorse third party applications, and does not evaluate how our original legal content is displayed on other sites. Consumers should form their own conclusions as to whether the downloaded data can be relied upon within an application or mash-up. An application may link to the official _Code of Federal Regulations_ on FDsys to provide users with additional assurance. 
+
+&nbsp;
+
+**Q. Do OFR and GPO assert any control over downstream uses of bulk data?**
+
+**A.** In general, there are no restrictions on re-use of information in Code of Federal Regulations material because U.S. Government works are not subject to copyright. OFR and GPO do not restrict downstream uses of Code of Federal Regulations data, except that independent providers should be aware that only the OFR and GPO are entitled to represent that they are the providers of the official versions of the _Code of Federal Regulations_ and related Federal Register publications. 
+
+&nbsp;
+
+**Q. How can re-publishers indicate the source of Code of Federal Regulations data?**
+
+**A**. Re-publishers of Code of Federal Regulations data may cite FDsys and OFR/GPO as the source of their data, and they are free to characterize the quality of data as it appears on their site. But private sector re-publishers are prohibited from using the seal of the National Archives and Records Administration (NARA) or stylized Code of Federal Regulations logos identified in NARA regulations (36 CFR part 1200) on their products because that would unlawfully misrepresent the legal status of the material, and could falsely identify private organizations as entities of the Federal Government.
+
+&nbsp;
+
+#2 Schema Description
+
+The schema chosen to represent the Code of Federal Regulations is a simplified version of the SGML schema that is used as part of the print production process, with some presentation and print specific tags removed or collapsed, and then converted to well-formed XML. This schema was chosen for the following reasons:
+
+1. It is a complete and faithful representation of the Code of Federal Regulations, which matches most closely to the author's original intent.
+2. It describes the data using semantic tags in a way that is appropriate to the Code of Federal Regulations Domain. For example, `<TOC>`, `<CITE>`, `<SECTION>`, and `<CHAPTER>` are all tags in this schema but they are not a complete set of all possible tags.
+3. It fully describes the structure of the Code of Federal Regulations, including the large structure (chapters, parts, sections, etc.), the document structure (paragraphs, etc.), and semantic structure.
+
+Since the schema is not an authoring schema and the SGML to XML conversion process maintains the order of the tags, this allows the XML schema to be more permissive than if it were used for checking authored content.
+
+The schema being produced for this effort describes the data as it actually occurs from the OFR. Documents are not being cleaned up because they do not match the schema; instead, the schema was selectively relaxed. Such an approach maintains 100% fidelity to the original data, and eliminates any errors that might occur in schema interpretation or further data manipulation.
+
+The following table lists the SGML tags that were removed or collapsed into a source attribute in the Code of Federal Regulations XML.
+
+&nbsp;
+
+| Purposed Fields to be Removed | Fields to be Removed or Collapsed | Description |
+| --- | --- | --- |
+| FNC | Removed | Used to generate a new column. |
+| Q | Removed | Insert vertical space. |
+| FNP | Removed | Used to generate a new even page. |
+| FP | Collapse to FP | Flush paragraph entries. |
+| FP-1 | Collapse to FP | Flush paragraph, turnovers indented one em. |
+| FP-2 | Collapse to FP | Flush paragraph, turnovers indented two ems. |
+| FP-DASH | Collapse to FP | Used for flush paragraphs that fill with dashesu. |
+| FP1 | Collapse to FP | First level indented flush paragraph. |
+| FP1-2 | Collapse to FP | Paragraph, first line indented one em and turnovers indented two ems. |
+| FP2 | Collapse to FP | Second level flush paragraph, all lines indented two ems. |
+| FP2-2 | Collapse to FP | Second level indented paragraph with turnovers indented two .levels also. |
+| FP2-3 | Collapse to FP | Second level indented paragraph with turnovers indented three levels. |
+| FP3 | Collapse to FP | Third level indented flush paragraph. |
+| FP4 | Collapse to FP | Fourth level indented flush paragraph. |
+| FRP | Collapse to FP | Flush right material, actually held in 1 em from right margin. |
+| FRP0 | Collapse to FP | True flush right material. |
+| HD | Collapse to HD | First level head in the following sections. |
+| HD1 | Collapse to HD | Usually used for first level (bold?) head. |
+| HD2 | Collapse to HD | Usually used for second level (caps and small caps?) head. |
+| HD3 | Collapse to HD | Usually used for third level (italic?) head. |
+| HD4 | Collapse to HD | Usually used for fourth level (roman?) heads. |
+| HD5 | Collapse to HD | Fifth level head in the following sections. |
+| HD6 | Collapse to HD | Sixth level head in the following sections. |
+| HD8 | Collapse to HD | Lowest level head in the following sections. |
+| HED | Collapse to HD | Usually the first head within a group or container where the group or container is designated for search and retrieval purposes. |
+| HED1 | Collapse to HD | Special first level head in text of Section. |
+| THED | Collapse to HD | Head that turns sideways on the page. |
+| P | Collapse to P | Normally used for paragraph. A paragraph here has the first line indented. |
+| NPAR | Collapse to P | Used to generate a new paragraph where the `<P>` tag would create a run in entry. |
+| P-1 | Collapse to P | Paragraph, turnovers indent one level. |
+| P-2 | Collapse to P | Paragraph, turnovers indented two ems on left. |
+| P-3 | Collapse to P | Paragraph, turnovers indent third level. |
+| P-DASH | Collapse to P | Used for paragraphs that fill with dashes. |
+| P1 | Collapse to P | First level indent paragraph. |
+| P2 | Collapse to P | Second level indent paragraph. |
+| P2-3 | Collapse to P | Second level indent paragraph, turnovers indent third level. |
+| P4-5 | Collapse to P | Special indents for BLM index. |
+| P6-7 | Collapse to P | Special indents for BLM index. |
+| P8-9 | Collapse to P | Special indents for BLM index. |
+| SUBJECT | Collapse to SUBJECT | Subject of Section, usually follows Section Number. |
+| SUBJECT1 | Collapse to SUBJECT | First level indented subject in special indexes. |
+| SUBJECT2 | Collapse to SUBJECT | Second level indented subject in special indexes. |
+| SUBJECT3 | Collapse to SUBJECT | Third level indented subject in special indexes. |
+| SUBJL | Collapse to SUBJL | Lead subject in special indexes. |
+| SUBJ1L | Collapse to SUBJL | First level lead subject in special indexes. |
+| SUBJ2L | Collapse to SUBJL | Second level lead subject in special indexes. |
+| SUBJ3L | Collapse to SUBJL | Third level lead subject in special indexes. |
+| SUBJ4L | Collapse to SUBJL | Fourth level lead subject in special indexes. |
+
+##2.2 Table of Contents, Explanatory Text, Title Number, and Finding Aid Entries 
+
+This section describes the top-level structure of Code of the Federal Regulations XML file.
+
+The XML schema, being a translated reproduction of the SGML schema, contains tags and content in the same order as they appear in the printed document. Major sections are grouped appropriately (`<TOC>`, `<PART>`, `<SUBPART>`, `<CITE>`, `<EXPLA>`, `<SECTION>`, `<CHAPTER>`, `<ALPHLIST>`), and all data and tags are represented – with the exception of the reduced tags from the previous section. **The XML tags above are not a complete set of what is available in the Code of Federal Regulations.**
+
+The XML tags and their descriptions of the TOC schema above is shown below:
+
+| XML Tag | Description |
+| --- | --- |
+| CFRDOC | The root tag for all document types in Code of Federal Regulations publications. This tag includes children such as TOC, CITE, EXPLA, SECTION, CHAPTER and ALPHLIST. Note: These children are not a complete set of tags. See the CFRDOC.XSD for more details.  |
+| TOC | Contains the main table of contents in major divisions of publication. |
+| TITLENO | Contains title number in tables of contents. |
+| SUBTI | Contains subtitle head in table of contents. |
+| PGHD | Usually, it contains the word "Page" when it appears as a heading. |
+| EXPL | Used for explanatory data following the "Cite this Code" page. |
+| SUBJECT | Contains subject of section, usually follows section number. |
+| PG | Used for page number data in lists. |
+| CHAPTI | Contains chapter division in tables of contents sections. |
+| FAIDS | Finding Aids entries |
+
+&nbsp;
+
+An abbreviated example of the overall section and structure is below:
+
+&nbsp;
+
+```<CFRDOC>  
+ .  
+ .  
+ .  
+ <TOC>  
+    <HD SOURCE="HED">Table of Contents</HD>  
+    <PGHD>Page</PGHD>  
+    <EXPL>  
+        <SUBJECT>Explanation</SUBJECT>  
+        <PG>v</PG>  
+    </EXPL>  
+    <TITLENO>  
+        <HD SOURCE="HED">Title 7:</HD>  
+        <SUBTI>  
+            <HD SOURCE="HED">Subtitle B—Regulations of the...</HD>  
+        </SUBTI>  
+        <CHAPTI>  
+            <SUBJECT>Chapter X—Agricultural Marketing Service... </SUBJECT>  
+            <PG>5</PG>  
+        </CHAPTI>  
+    </TITLENO>  
+    <FAIDS>  
+        <HD SOURCE="HED">Finding Aids:</HD>  
+        <SUBJECT>Table of CFR Titles and Chapters</SUBJECT>  
+        <PG>225</PG>  
+        <SUBJECT>Alphabetical List of Agencies Appearing in...</SUBJECT>  
+        <PG>245</PG>  
+        <SUBJECT>List of CFR Sections Affected</SUBJECT>  
+        <PG>255</PG>  
+    </FAIDS>  
+</TOC>  
+.  
+.  
+.  
+</CFRDOC>```
+
+###2.2.2 XPath Examples
+
+The schema allows for a wide variety XPath commands for extracting items:
+
+//SECTION ? outputs all sections within Code of Federal Regulations document.
+
+(//SECTION/SECTNO ? Returns all the section numbers.
+
+(//SECTION/SUBJECT ? Returns all the subjects within all sections.
+
+//SECTION[descendant::PRTPAGE/@P = 'iii'] ? Returns section contents which contains page iii.
+
+##2.3 TITLE, CHAPTER, PART and SUBPART 
+
+The TITLE, CHAPTER, PART and SUBPART tags are organized in an xml structure that is defined below and contains logical divisions in the Code of Federal Regulations. For example, each title is divided into chapters, which usually bear the name of the issuing agency. Each chapter is further subdivided into parts that cover specific regulatory areas. Large parts may be subdivided into subparts. All parts are organized in sections, and most citations in the CFR are provided at the section level.
+
+&nbsp;
+
+The XML tags and their descriptions of the schema above are shown below:
+
+&nbsp;
+
+| XML Tag | Description |
+| --- | --- |
+| TITLE | Contains a major group of the publication. |
+| SUBCHAP | Contains a major division within a Chapter. |
+| CONTENTS | Contains table of contents entries. |
+| SECHD | Usually used for the words "Section" or "Sec." when it appears as heading. |
+| SECTNO | Used for the CFR section number. |
+| SUBJECT | Subject of Section, usually follows Section Number. |
+| APP | Used for Appendix head entries in tables of contents. |
+| CHAPTER | Contains a major division within Title and Subtitle. |
+| PART | Contains a major division within Chapters and Subchapters. |
+| EAR | Used to override default entry for first or last section number in running head. |
+| SUBPART | Contains a major division within Part. |
+| RESERVED | Used mostly for units that are reserved for future use, and therefore contain no data at this time. |
+
+&nbsp;
+
+The abbreviated example of the TITLE, CHAPTER, PART and SUBPART tags are shown below.
+
+&nbsp;
+
+```<CFRDOC>  
+  .
+  .
+  .
+    <TITLE>  
+        <CHAPTER>  
+            <SUBCHAP>  
+                <HD SOURCE="HED">SUBCHAPTER C—AIR PROGRAMS (CONTINUED)</HD>  
+                <PART>  
+                    <HD SOURCE="HED">PART 53—AMBIENT AIR MONITORING...</HD>  
+                    <CONTENTS>
+                         .
+                         .
+                         .  
+                        <SUBPART>  
+                            <HD SOURCE="HED">Subpart A—General Provisions</HD>  
+                            <SECHD>Sec.</SECHD>  
+                            <SECTNO>53.1</SECTNO>  
+                            <SUBJECT>Definitions.</SUBJECT>  
+                            <SECTNO>53.2</SECTNO>  
+                            <SUBJECT>General requirements for a...</SUBJECT>  
+                            <SECTNO>53.3</SECTNO>  
+                            <SUBJECT>General requirements for an...</SUBJECT>
+                        </SUBPART>
+                         .
+                         .
+                         .  
+                        <SUBPART>  
+                            <HD SOURCE="HED">Subpart B—Procedures for...</HD>  
+                            <SECTNO>53.20</SECTNO>  
+                            <SUBJECT>General provisions.</SUBJECT>  
+                            <SECTNO>53.21</SECTNO>  
+                            <SUBJECT>Test conditions.</SUBJECT>
+                        </SUBPART>
+                         .
+                         .
+                         .
+                        <APP><E T="04">Appendix A to Subpart...</E></APP>
+                         .
+                         .
+                         .
+                  </CONTENTS>  
+                </PART>  
+            </SUBCHAP>  
+        </CHAPTER>  
+    </TITLE>  
+  .
+  .
+  .
+</CFRDOC>```
+
+&nbsp;
+
+&nbsp;
+
+##2.4.Cite This Code 
+
+Cite this code section holds the first text line of cite this code pages followed by explanatory data. The contents of a CITE always includes a CITEP paragraph on the regulation. Cite this code section is followed by EXPLA section which explains the data of Code of Federal Regulations. The signature block is often followed by EXPLA section and may contain empty xml values. &nbsp; &nbsp;
+
+The XML tags and their descriptions of the schema above are shown below:
+
+&nbsp;
+
+| XML Tag | Description |
+| --- | --- |
+| CITE | Contains the first text line of "cite this code" page. |
+| CITEP | Contains "To Cite ..." paragraph on cite this code page in front matter |
+| EXPLA | Used for explanatory data following the "Cite this Code" page in the front matter |
+| IPAR | Contains lead material on first page of explanation section of the front matter. |
+| STUB | Contains the back part of lead material. |
+| SIDEHED | Used within explanatory data following the "Cite this Code" page in the front matter. |
+| SIG | Used to designate a signature block. |
+| NAME | Used for person's name. |
+| POSITION | Used to denote the job title only in signature blocks. |
+| OFFICE | Used for the "Office of the Federal Register" line in the signature block of the explanation pages of the Front matter. |
+| DATE | Used for date entry. |
+
+&nbsp;
+
+An abbreviated example of the CITE and EXPLA section and structure is below:
+
+&nbsp;
+
+```<CFRDOC>
+ .
+ .
+ .
+  <CITE>  
+      <P>Cite this Code:<E T="01">CFR</E></P>  
+      <CITEP>To cite the regulations in this volume use title...</CITEP>  
+  </CITE>  
+  <EXPLA>  
+      <HD SOURCE="HED">Explanation</HD>  
+      <P>The Code of Federal Regulations is a codification of the...</P>  
+      <P>Each volume of the Code is revised at least once each...</P>  
+      <IPAR>  
+          <P SOURCE="P1">Title 1 through Title 16 </P>  
+          <STUB>as of January 1</STUB>  
+          <P SOURCE="P1">Title 17 through Title 27 </P>  
+          <STUB>as of April 1</STUB>  
+          .  
+          .  
+          .  
+      </IPAR>  
+      <P>The appropriate revision date is printed on the cover of each...</P>  
+      <SIDEHED>  
+          <HD SOURCE="HED">LEGAL STATUS</HD>  
+          <P>The contents of the Federal Register are required to be...</P>  
+      </SIDEHED>  
+      <SIDEHED>  
+          <HD SOURCE="HED">HOW TO USE THE CODE OF FEDERAL REGULATIONS</HD>  
+          <P>The Code of Federal Regulations is kept up to date by the...</P>  
+          <P>To determine whether a Code volume has been amended since...</P>  
+      </SIDEHED>  
+      .  
+      .  
+      .  
+      <SIG>  
+          <NAME/>  
+          <POSITION/>  
+          <OFFICE/>  
+      </SIG>  
+      <DATE/>  
+  </EXPLA>
+ .
+ .
+ .
+</CFRDOC>```
+
+&nbsp;
+
+##2.5.The Contents of Section
+
+The contents of section tags are the ones that usually describe the majority of the data in the Code of Federal Regulations. In some cases, the section includes XML GPOTABLE tags which describe elements of tables and their data. Section tag always contains a section number which is usually followed by a subject of that section. A paragraph or XML tag P is used to denote large or small text in the section. In some cases, a section may also contain a citation.
+
+&nbsp;
+
+| XML Tag | Description |
+| --- | --- |
+| SECTION | Contains group or container tag for search and retrieval purposes. |
+| SECTNO | Used for the code of Federal Regulations section number. |
+| SUBJECT | Contains subject of section, usually follows section number. |
+| GPOTABLE | Defines the elements necessary to produce the structure of GPO tables. |
+| BOXHD | Generation of box heads delimiter. It is used only if there are actual CHEDs in the table. |
+| CHED | Generation of column boxheads. Do not use if there are no actual CHEDs in the table. |
+| ROW | Generation row delimiter. |
+| ENT | Generation table body cell. |
+| CITA | Used for citations. |
+
+&nbsp;
+
+The contents will roughly have the same structure:
+
+&nbsp;
+
+```<CFRDOC>
+ .
+ .
+ .
+
+ <SECTION>  
+   <SECTNO>§ 1007.51</SECTNO>  
+   <SUBJECT>Class I differential, adjustments to Class I prices...</SUBJECT>  
+   <P>(a) The Class I differential shall be the differential...</P>  
+   <P>(b) Adjustment to Class I prices. Class I prices shall...</P>  
+   <GPOTABLE CDEF="xs60,r100,13,13," COLS="4" OPTS="L2">  
+     <BOXHD>  
+       <CHED H="1">State</CHED>  
+       <CHED H="1">Country/parish</CHED>  
+       <CHED H="1">FIPS</CHED>  
+       <CHED H="1">Class I price adjustment</CHED>  
+     </BOXHD>  
+     <ROW>  
+       <ENT I="01">AL</ENT>  
+       <ENT>AUTAUGA</ENT>  
+       <ENT>01001</ENT>  
+       <ENT>0.50</ENT>  
+     </ROW>  
+     .  
+     .  
+     .  
+   </GPOTABLE>  
+   <CITA>[73 FR 14163, Mar. 17, 2008]</CITA>  
+ </SECTION>
+ .
+ .
+ .
+</CFRDOC>```
+
+&nbsp;
+
+##2.6.Chapter Tag
+
+The CHAPTER tag holds contents that list agency names along with their code of Federal Regulations data. It contains chapter number entries and repeatable Code of Federal Regulations numbers heads.
+
+The XML tags and descriptions of the schema above are shown below:
+
+&nbsp;
+
+| XML Tag | Description |
+| --- | --- |
+| CHAPTER | Used for group or container tag for search and retrieval purposes. |
+| CHAPNO | Used for chapter number entries in the "List of Code of Federal Regulations Sections Affected" section in Back matter and elsewhere. |
+| AGENCY | Agency names appearing the CFR. |
+| CFRHD | Contains repeatable "CFR, Title." Head in Alphabetical Listing of Agencies in Back matter. |
+| ONOTE | Contains "Material Approved for Incorporation by Reference" section of Back matter. |
+| OWNER | Contains "Material Approved for Incorporation by Reference" section of Back matter. |
+| ADDR | Contains Address of organization publishing standards that follow. Used in "Material Approved for Incorporation by Reference" section of back matter. |
+| PUBLI | Used for publications. |
+| CFRNO | Repeatable CFR Number heads in Material Incorporated for Reference and List of CFR Sections Affected section of Back matter. |
+
+&nbsp;
+
+An abbreviated example of the CHAPTER section and structure is below:
+
+&nbsp;
+
+```	<CFRDOC>
+ .
+ .
+ .
+ <CHAPTER>  
+   <CHAPNO>10 CFR (PARTS 200-499)</CHAPNO>  
+   <AGENCY>DEPARTMENT OF ENERGY</AGENCY>  
+   <CFRHD>10 CFR</CFRHD>  
+   <ONOTE>PART 300—VOLUNTARY GREENHOUSE GAS REPORTING PROGRAM...</ONOTE>  
+   <OWNER>US Department of Energy, Office of Policy and International…</OWNER>  
+   <ADDR>1000 Independence Avenue, SW; Washington, DC 20585</ADDR>  
+   <PUBLI>Technical Guidelines for the Voluntary Reporting of...</PUBLI>  
+   <CFRNO>300.1, 300.5, 300.6, 300.8, 300.9, 300.12, 300.13</CFRNO>  
+   <ONOTE>PART 420—STATE ENERGY PROGRAM</ONOTE>  
+   <OWNER>American Society of Heating, Refrigerating and Air...</OWNER>  
+   .  
+   .  
+   .  
+ </CHAPTER>
+ .
+ .
+ .
+
+</CFRDOC>```
+
+&nbsp;
+
+##2.7.ALPHLIST Tag
+
+The ALPHLIST tag contains list of agencies appearing in the Code of Federal Regulations documents. This information may include revised tag with a date along with repeatable agency tags and CFRID values. The XML tags and their descriptions of the ALPHLIST schema are shown below.
+
+&nbsp;
+
+| XML Tag | Description |
+| --- | --- |
+| ALPHLIST | Alphabetical List of Agencies Appearing in the code of Federal Regulations. |
+| REV | Contains "Revised as of" line under Head. |
+| AGHD | Contains Repeatable "Agency" head. &nbsp;It is used only in alphabetical list of agencies in Back matter. |
+| CFRID | Contains CFR Title, Subtitle, or Chapter data in second column of Alphabetical Listing of Agencies in Back matter. |
+
+&nbsp;
+
+An abbreviated example of the ALPHLIST section and structure is below:
+
+&nbsp;
+
+```<CFRDOC>
+
+&nbsp; .
+
+&nbsp; .
+
+&nbsp; .
+
+&nbsp; <ALPHLIST>  
+ &nbsp; &nbsp;<HD SOURCE="HED">Alphabetical List of Agencies Appearing in the...</HD>  
+ &nbsp; &nbsp;<REV>(Revised as of January 1, 2009)</REV>  
+ &nbsp; &nbsp;<AGHD>Agency</AGHD>  
+ &nbsp; &nbsp;<CFRHD>CFR Title, Subtitle or Chapter</CFRHD>  
+ &nbsp; &nbsp;<AGENCY>Administrative Committee of the Federal Regulations</AGENCY>  
+ &nbsp; &nbsp;<CFRID>1, I</CFRID>  
+ &nbsp; &nbsp;<AGENCY>Advanced Research Projects Agency</AGENCY>  
+ &nbsp; &nbsp;<CFRID>32, I</CFRID>
+
+&nbsp; &nbsp; .
+
+&nbsp; &nbsp; .
+
+&nbsp; &nbsp; .  
+ &nbsp;</ALPHLIST>
+
+&nbsp; .
+
+&nbsp; .
+
+&nbsp; .
+
+</CFRDOC>```
+
+&nbsp;
+
+#3.Resources Directory
+
+The resources directory(http://www.gpo.gov/fdsys/bulkdata/CFR/resources) in the Code of Federal Regulations bulk data repository contains the current version of the XML schema, the XML stylesheet used to display the XML files in a browser on the FDsys website, and this user guide in PDF.

--- a/CFR-XML_User-Guide.md
+++ b/CFR-XML_User-Guide.md
@@ -227,7 +227,8 @@ An abbreviated example of the overall section and structure is below:
 .  
 .  
 .  
-</CFRDOC>```
+</CFRDOC>
+```
 
 ###2.2.2 XPath Examples
 
@@ -399,7 +400,8 @@ An abbreviated example of the CITE and EXPLA section and structure is below:
  .
  .
  .
-</CFRDOC>```
+</CFRDOC>
+```
 
 &nbsp;
 
@@ -459,7 +461,8 @@ The contents will roughly have the same structure:
  .
  .
  .
-</CFRDOC>```
+</CFRDOC>
+```
 
 &nbsp;
 
@@ -555,7 +558,8 @@ An abbreviated example of the ALPHLIST section and structure is below:
   .
   .
   .
-</CFRDOC>```
+</CFRDOC>
+```
 
 &nbsp;
 

--- a/CFR-XML_User-Guide.md
+++ b/CFR-XML_User-Guide.md
@@ -37,7 +37,7 @@ The purpose of this document is to provide an overview of Code of Federal Regula
 
 **Q. &nbsp;Are bulk data downloads of XML files offered on FDsys via Data.gov and FDsys part of the official version of the Code of Federal Regulations?**
 
-**A.** No, the XML-structured files offered for bulk download are not part of the official on-line format of the _Code of Federal Regulations_. While GPO's XML files are based on the original source data submitted by Federal agencies, OFR markup, and GPO typesetting and composition markup in SGML, only the PDF and Text versions of _Code of Federal Regulations_content on GPO Access and FDsys have legal status as parts of the official online format of the _Code of Federal Regulations_. &nbsp;Additional development will be required before OFR/GPO can specify that XML files are a part of the official online edition of the _Code of Federal Regulations_. &nbsp;
+**A.** No, the XML-structured files offered for bulk download are not part of the official on-line format of the _Code of Federal Regulations_. While GPO's XML files are based on the original source data submitted by Federal agencies, OFR markup, and GPO typesetting and composition markup in SGML, only the PDF and Text versions of _Code of Federal Regulations_ content on GPO Access and FDsys have legal status as parts of the official online format of the _Code of Federal Regulations_. &nbsp;Additional development will be required before OFR/GPO can specify that XML files are a part of the official online edition of the _Code of Federal Regulations_. &nbsp;
 
 &nbsp;
 
@@ -170,7 +170,7 @@ The following table lists the SGML tags that were removed or collapsed into a so
 
 This section describes the top-level structure of Code of the Federal Regulations XML file.
 
-The XML schema, being a translated reproduction of the SGML schema, contains tags and content in the same order as they appear in the printed document. Major sections are grouped appropriately (`<TOC>`, `<PART>`, `<SUBPART>`, `<CITE>`, `<EXPLA>`, `<SECTION>`, `<CHAPTER>`, `<ALPHLIST>`), and all data and tags are represented – with the exception of the reduced tags from the previous section. **The XML tags above are not a complete set of what is available in the Code of Federal Regulations.**
+The XML schema, being a translated reproduction of the SGML schema, contains tags and content in the same order as they appear in the printed document. Major sections are grouped appropriately (`<TOC>`, `<PART>`, `<SUBPART>`, `<CITE>`, `<EXPLA>`, `<SECTION>`, `<CHAPTER>`, `<ALPHLIST>`), and all data and tags are represented Â– with the exception of the reduced tags from the previous section. **The XML tags above are not a complete set of what is available in the Code of Federal Regulations.**
 
 The XML tags and their descriptions of the TOC schema above is shown below:
 
@@ -207,10 +207,10 @@ An abbreviated example of the overall section and structure is below:
     <TITLENO>  
         <HD SOURCE="HED">Title 7:</HD>  
         <SUBTI>  
-            <HD SOURCE="HED">Subtitle B—Regulations of the...</HD>  
+            <HD SOURCE="HED">Subtitle BÂ—Regulations of the...</HD>  
         </SUBTI>  
         <CHAPTI>  
-            <SUBJECT>Chapter X—Agricultural Marketing Service... </SUBJECT>  
+            <SUBJECT>Chapter XÂ—Agricultural Marketing Service... </SUBJECT>  
             <PG>5</PG>  
         </CHAPTI>  
     </TITLENO>  
@@ -279,15 +279,15 @@ The abbreviated example of the TITLE, CHAPTER, PART and SUBPART tags are shown b
     <TITLE>  
         <CHAPTER>  
             <SUBCHAP>  
-                <HD SOURCE="HED">SUBCHAPTER C—AIR PROGRAMS (CONTINUED)</HD>  
+                <HD SOURCE="HED">SUBCHAPTER CÂ—AIR PROGRAMS (CONTINUED)</HD>  
                 <PART>  
-                    <HD SOURCE="HED">PART 53—AMBIENT AIR MONITORING...</HD>  
+                    <HD SOURCE="HED">PART 53Â—AMBIENT AIR MONITORING...</HD>  
                     <CONTENTS>
                          .
                          .
                          .  
                         <SUBPART>  
-                            <HD SOURCE="HED">Subpart A—General Provisions</HD>  
+                            <HD SOURCE="HED">Subpart AÂ—General Provisions</HD>  
                             <SECHD>Sec.</SECHD>  
                             <SECTNO>53.1</SECTNO>  
                             <SUBJECT>Definitions.</SUBJECT>  
@@ -300,7 +300,7 @@ The abbreviated example of the TITLE, CHAPTER, PART and SUBPART tags are shown b
                          .
                          .  
                         <SUBPART>  
-                            <HD SOURCE="HED">Subpart B—Procedures for...</HD>  
+                            <HD SOURCE="HED">Subpart BÂ—Procedures for...</HD>  
                             <SECTNO>53.20</SECTNO>  
                             <SUBJECT>General provisions.</SUBJECT>  
                             <SECTNO>53.21</SECTNO>  
@@ -433,7 +433,7 @@ The contents will roughly have the same structure:
  .
 
  <SECTION>  
-   <SECTNO>§ 1007.51</SECTNO>  
+   <SECTNO>Â§ 1007.51</SECTNO>  
    <SUBJECT>Class I differential, adjustments to Class I prices...</SUBJECT>  
    <P>(a) The Class I differential shall be the differential...</P>  
    <P>(b) Adjustment to Class I prices. Class I prices shall...</P>  
@@ -497,12 +497,12 @@ An abbreviated example of the CHAPTER section and structure is below:
    <CHAPNO>10 CFR (PARTS 200-499)</CHAPNO>  
    <AGENCY>DEPARTMENT OF ENERGY</AGENCY>  
    <CFRHD>10 CFR</CFRHD>  
-   <ONOTE>PART 300—VOLUNTARY GREENHOUSE GAS REPORTING PROGRAM...</ONOTE>  
-   <OWNER>US Department of Energy, Office of Policy and International…</OWNER>  
+   <ONOTE>PART 300Â—VOLUNTARY GREENHOUSE GAS REPORTING PROGRAM...</ONOTE>  
+   <OWNER>US Department of Energy, Office of Policy and InternationalÂ…</OWNER>  
    <ADDR>1000 Independence Avenue, SW; Washington, DC 20585</ADDR>  
    <PUBLI>Technical Guidelines for the Voluntary Reporting of...</PUBLI>  
    <CFRNO>300.1, 300.5, 300.6, 300.8, 300.9, 300.12, 300.13</CFRNO>  
-   <ONOTE>PART 420—STATE ENERGY PROGRAM</ONOTE>  
+   <ONOTE>PART 420Â—STATE ENERGY PROGRAM</ONOTE>  
    <OWNER>American Society of Heating, Refrigerating and Air...</OWNER>  
    .  
    .  

--- a/FR-XML_User-Guide.md
+++ b/FR-XML_User-Guide.md
@@ -6,7 +6,7 @@ Prepared by:Office of Programs, Strategy, and Technology
 
 Office of the Chief Technology Officer  
 U.S. Government Publishing Office
-&nbsp;
+ 
 
 ##Revision History
 
@@ -17,99 +17,92 @@ U.S. Government Publishing Office
 
 #1.Introduction
 
-The U.S. Government Printing Office (GPO) and the National Archives' Office of the Federal Register (OFR) partnership is offering bulk data downloads of Federal Register files to the general public via Data.gov and FDsys. &nbsp;This effort began when the President challenged Federal agencies to create a more open and transparent government, promote accountability, and provide information to citizens about what their Government is doing (see 74 FR 4685, January 26, 2009 at [http://www.gpo.gov/fdsys/pkg/FR-2009-01-26/pdf/E9-1777.pdf](http://www.gpo.gov/fdsys/pkg/FR-2009-01-26/pdf/E9-1777.pdf)). &nbsp;The Public Printer's letter of March 9, 2009 pledged to provide trusted information in whatever form is required to meet the President's objectives [http://www.gpo.gov/pdfs/news-media/letter\_030909.pdf](http://www.gpo.gov/pdfs/news-media/letter_030909.pdf). &nbsp;
+The U.S. Government Printing Office (GPO) and the National Archives' Office of the Federal Register (OFR) partnership is offering bulk data downloads of Federal Register files to the general public via Data.gov and FDsys.  This effort began when the President challenged Federal agencies to create a more open and transparent government, promote accountability, and provide information to citizens about what their Government is doing (see 74 FR 4685, January 26, 2009 at [http://www.gpo.gov/fdsys/pkg/FR-2009-01-26/pdf/E9-1777.pdf](http://www.gpo.gov/fdsys/pkg/FR-2009-01-26/pdf/E9-1777.pdf)).  The Public Printer's letter of March 9, 2009 pledged to provide trusted information in whatever form is required to meet the President's objectives [http://www.gpo.gov/pdfs/news-media/letter\_030909.pdf](http://www.gpo.gov/pdfs/news-media/letter_030909.pdf).  
 
-&nbsp;
+ 
 
-In addition, the Office of the Federal Register coordinates with the Office of Science Technology Policy to ensure that the OFR/GPO partnership meets customer expectations. &nbsp; To follow through on our commitment, we are expanding and accelerating the development of FDsys to provide XML-structured content as rendered output. &nbsp;This will give users access to masses of data to reconfigure and redistribute as they wish to meet the specialized needs of their constituencies. &nbsp;
+In addition, the Office of the Federal Register coordinates with the Office of Science Technology Policy to ensure that the OFR/GPO partnership meets customer expectations.   To follow through on our commitment, we are expanding and accelerating the development of FDsys to provide XML-structured content as rendered output.  This will give users access to masses of data to reconfigure and redistribute as they wish to meet the specialized needs of their constituencies.  
 
 ##1.1.Purpose
 
-The purpose of this document is to provide an overview of Federal Register XML files and associated schema. The FDsys Bulk Data repository at [http://www.gpo.gov/fdsys/bulkdata/](http://www.gpo.gov/fdsys/bulkdata/) contains the Federal Register in XML from 2000 to the present. Please see FDsys at [www.fdsys.gov](http://www.fdsys.gov/) for access to the Federal Register in PDF and HTML formats. &nbsp;
+The purpose of this document is to provide an overview of Federal Register XML files and associated schema. The FDsys Bulk Data repository at [http://www.gpo.gov/fdsys/bulkdata/](http://www.gpo.gov/fdsys/bulkdata/) contains the Federal Register in XML from 2000 to the present. Please see FDsys at [www.fdsys.gov](http://www.fdsys.gov/) for access to the Federal Register in PDF and HTML formats.  
 
 ##1.2.Legal Status & Authenticity of Federal Register files via Data.gov
 
-&nbsp;
+ 
 
 **Q. What is the data set available for the Federal Register in XML?**
 
-&nbsp;
+**A.** Federal Register files in XML have been converted and simplified from the SGML rendition used for the printed publication. The Federal Register is available in XML starting with the year 2000, when GPO began composing Federal Register material in SGML. OFR/GPO plan to convert the remaining electronic data set for the _Federal Register_ (1994-1999) at a future date.
 
-**A. &nbsp; &nbsp; &nbsp; &nbsp;** Federal Register files in XML have been converted and simplified from the SGML rendition used for the printed publication. The Federal Register is available in XML starting with the year 2000, when GPO began composing Federal Register material in SGML. OFR/GPO plan to convert the remaining electronic data set for the Federal Register (1994-1999) at a future date.
+ 
 
-&nbsp;
+**Q.  Are bulk data downloads of XML files offered on FDsys via Data.gov part of the official version of the _Federal Register_?**
 
-**Q. &nbsp;Are bulk data downloads of XML files offered on FDsys via Data.gov part of the official version of the _Federal Register_?**
+ 
 
-&nbsp;
+**A.**  No, the XML-structured files offered for bulk download are not part of the official on-line format of the _Federal Register_. While GPO's XML files are based on the original source data submitted by Federal agencies, OFR markup, and GPO typesetting and composition markup in SGML, only the PDF and Text versions of _Federal Register_ content on GPO Access and FDsys have legal status as parts of the official online format of the _Federal Register_.  Additional development will be required before OFR/GPO can specify that XML files are a part of the official online edition of the _Federal Register_.  
 
-**A.** &nbsp;No, the XML-structured files offered for bulk download are not part of the official on-line format of the _Federal Register_. While GPO's XML files are based on the original source data submitted by Federal agencies, OFR markup, and GPO typesetting and composition markup in SGML, only the PDF and Text versions of _Federal Register _content on GPO Access and FDsys have legal status as parts of the official online format of the _Federal Register_. &nbsp;Additional development will be required before OFR/GPO can specify that XML files are a part of the official online edition of the _Federal Register_. &nbsp;
+ 
 
-&nbsp;
+**Q.  Do OFR/GPO plan to include XML files as part of the official format of the Federal Register?**
 
-**Q. &nbsp;Do OFR/GPO plan to include XML files as part of the official format of the Federal Register?**
+ 
 
-&nbsp;
+**A.**  Yes. The current set of XML-structured material (minus graphics) is not yet characterized as part of the official online _Federal Register_ format because the underlying data used to create a viewable rendition of the material must be thoroughly scrutinized and tested. The XML-structured files are derived from SGML-tagged data and printing codes, which may produce anomalies in display.  For example, complex tabular material in XML files may not display as correctly composed objects equivalent to the tables that appear in the Text and PDF files.  Tabular material that displays in an ambiguous or distorted manner could affect the substantive meaning of regulations and other documents.  
 
-**A.** &nbsp;Yes. The current set of XML-structured material (minus graphics) is not yet characterized as part of the official online _Federal Register _format because the underlying data used to create a viewable rendition of the material must be thoroughly scrutinized and tested. The XML-structured files are derived from SGML-tagged data and printing codes, which may produce anomalies in display. &nbsp;For example, complex tabular material in XML files may not display as correctly composed objects equivalent to the tables that appear in the Text and PDF files. &nbsp;Tabular material that displays in an ambiguous or distorted manner could affect the substantive meaning of regulations and other documents. &nbsp;
+ 
 
-&nbsp;
+Our goal is to clean up the XML data and develop associated style sheets to the point that the XML rendition can be characterized as a display format of the official online edition.  We are also developing the means to embed graphics in the files, so that an XML version may be deemed both official and complete.  The OFR will issue a _Federal Register Bulletin_ to alert users when the XML-structured files are ready to be included as part of the official online edition.  
 
-Our goal is to clean up the XML data and develop associated style sheets to the point that the XML rendition can be characterized as a display format of the official online edition. &nbsp;We are also developing the means to embed graphics in the files, so that an XML version may be deemed both official and complete. &nbsp;The OFR will issue a _Federal Register Bulletin_ to alert users when the XML-structured files are ready to be included as part of the official online edition. &nbsp;
+**Q.  What is the legal basis for making determinations about official status?**
 
-**Q. &nbsp;What is the legal basis for making determinations about official status?**
+**A.**  The Federal Register Act established the Administrative Committee of the Federal Register (Administrative Committee or ACFR) as the regulatory body with authority to determine the format(s) of the official serial publication known as the _Federal Register _(44 U.S.C. Ch. 15). Under 1 CFR 5.10, the official formats approved by the ACFR include a paper edition, a microfiche edition, and an online edition.  OFR and GPO carry out ACFR regulations by developing appropriate means to display Federal Register material in the official formats.  
 
-**A.** &nbsp;The Federal Register Act established the Administrative Committee of the Federal Register (Administrative Committee or ACFR) as the regulatory body with authority to determine the format(s) of the official serial publication known as the _Federal Register _(44 U.S.C. Ch. 15). Under 1 CFR 5.10, the official formats approved by the ACFR include a paper edition, a microfiche edition, and an online edition. &nbsp;OFR and GPO carry out ACFR regulations by developing appropriate means to display Federal Register material in the official formats. &nbsp;
-
-&nbsp;
+ 
 
 Q. When did the Federal Register first appear online?
 
-&nbsp;
+**A.** The official online edition dates to 1994 when Congress authorized an online edition in Public Law 103-40 (the Government Printing Office Electronic Information Enhancement Act of 1993; codified at 44 U.S.C. 4101).  
 
-**A.** The official online edition dates to 1994 when Congress authorized an online edition in Public Law 103-40 (the Government Printing Office Electronic Information Enhancement Act of 1993; codified at 44 U.S.C. 4101). &nbsp;
+ 
 
-&nbsp;
+Q.  Are Federal Register XML bulk download files digitally signed?
 
-Q. &nbsp;Are Federal Register XML bulk download files digitally signed?
+**A.** No, XML files available for download are not digitally signed.  They can be manipulated and enriched to operate in the various applications that users may devise. GPO is evaluating technology that could be used to digitally sign XML files for future official editions posted on FDsys.  Adding signed non-PDF files to FDsys would be an enhancement for FDsys users, but would not be used to restrict or adversely affect the XML bulk data downloads available to our customers.  
 
-No, XML files available for download are not digitally signed. &nbsp;They can be manipulated and enriched to operate in the various applications that users may devise. GPO is evaluating technology that could be used to digitally sign XML files for future official editions posted on FDsys. &nbsp;Adding signed non-PDF files to FDsys would be an enhancement for FDsys users, but would not be used to restrict or adversely affect the XML bulk data downloads available to our customers. &nbsp;
-
-**Q. &nbsp;What does the term "digitally signed" mean?**
-
-&nbsp;
+**Q.  What does the term "digitally signed" mean?**
 
 **A**. Currently, GPO uses digital signature technology on PDF documents to add a visible Seal of Authenticity (a graphic of an eagle) to authenticated and certified documents. The technology allows GPO to secure data integrity, and provide users with assurance that the content is unchanged since it was disseminated by GPO. A signed and certified document also displays a blue ribbon icon to the left of the Seal of Authenticity and in the Signatures tab within Adobe Acrobat or Reader. When users print a document that has been signed and certified by GPO, the Seal of Authenticity will automatically print on the document, but the blue ribbon will not print.
 
 **Q. How reliable is the metadata and the underlying tagging in bulk data files?**
 
-**A.** &nbsp;The document markup and metadata found within bulk data files are generally reliable and complete. &nbsp;However, there are variations in this underlying data due to inconsistencies in the composition and typesetting process. &nbsp;As a result, some data-mining applications and user aids may not produce 100 per cent accurate results. &nbsp;
+**A.**  The document markup and metadata found within bulk data files are generally reliable and complete.  However, there are variations in this underlying data due to inconsistencies in the composition and typesetting process.  As a result, some data-mining applications and user aids may not produce 100 per cent accurate results.  
 
-Q. &nbsp;What is the legal status of Federal Register user aids?
+Q.  What is the legal status of Federal Register user aids?
 
-**A.:** Federal Register user aids, including, finding aids, indexes, search tools, metadata associations, and tagging schemes are not part of the legal text of the _Federal Register_. &nbsp;These ancillary features help users explore and extract data, but the official legal text stands on its own. &nbsp;No person should form absolute legal conclusions based on search results, finding aids, metadata associations, extractions of data, and the like. &nbsp;Ultimately, only the official text of the _Federal Register_ may be relied upon as evidence in a court of law. &nbsp;
+**A.** Federal Register user aids, including, finding aids, indexes, search tools, metadata associations, and tagging schemes are not part of the legal text of the _Federal Register_.  These ancillary features help users explore and extract data, but the official legal text stands on its own.  No person should form absolute legal conclusions based on search results, finding aids, metadata associations, extractions of data, and the like.  Ultimately, only the official text of the _Federal Register_ may be relied upon as evidence in a court of law.  
 
-**Q. &nbsp;What is the authenticity of Federal Register bulk data files after they have been downloaded to another site? &nbsp;**
+**Q.  What is the authenticity of Federal Register bulk data files after they have been downloaded to another site?  **
 
-**A.** &nbsp; We cannot vouch for the authenticity of data that is not under OFR/GPO control. OFR and GPO are providing free access to Federal Register data via XML for display in various applications and mash-ups outside the FDsys domain. &nbsp;The OFR/GPO partnership does not endorse third party applications, and does not evaluate how our original legal content is displayed on other sites. &nbsp;Consumers should form their own conclusions as to whether the downloaded data can be relied upon within an application or mash-up. &nbsp;An application may link to the official _Federal Register_ on FDsys to provide users with additional assurance. &nbsp;
+**A.**   We cannot vouch for the authenticity of data that is not under OFR/GPO control. OFR and GPO are providing free access to Federal Register data via XML for display in various applications and mash-ups outside the FDsys domain.  The OFR/GPO partnership does not endorse third party applications, and does not evaluate how our original legal content is displayed on other sites.  Consumers should form their own conclusions as to whether the downloaded data can be relied upon within an application or mash-up.  An application may link to the official _Federal Register_ on FDsys to provide users with additional assurance.  
 
 **Q. Do OFR and GPO assert any control over downstream uses of bulk data?**
 
-**A.** &nbsp;In general, there are no restrictions on re-use of information in Federal Register documents because U.S. Government works are not subject to copyright. OFR and GPO do not restrict downstream uses of Federal Register data, except that independent providers should be aware that only the OFR and GPO are entitled to represent that they are the providers of the official versions of the _Federal Register_ and related Federal Register publications. &nbsp;
+**A.**  In general, there are no restrictions on re-use of information in Federal Register documents because U.S. Government works are not subject to copyright. OFR and GPO do not restrict downstream uses of Federal Register data, except that independent providers should be aware that only the OFR and GPO are entitled to represent that they are the providers of the official versions of the _Federal Register_ and related Federal Register publications.  
 
-&nbsp;
 
 Q. How can re-publishers indicate the source of Federal Register data?
 
-**A**. Re-publishers of Federal Register data may cite FDsys and OFR/GPO as the source of their data, and they are free to characterize the quality of data as it appears on their site. But private sector re-publishers are prohibited from using the seal of the National Archives and Records Administration (NARA) or stylized Federal Register logos identified in NARA regulations (36 CFR part 1200) on their products because that would unlawfully misrepresent the legal status of the material, and could falsely identify &nbsp;private organizations as entities of the Federal Government.
+**A.** Re-publishers of Federal Register data may cite FDsys and OFR/GPO as the source of their data, and they are free to characterize the quality of data as it appears on their site. But private sector re-publishers are prohibited from using the seal of the National Archives and Records Administration (NARA) or stylized Federal Register logos identified in NARA regulations (36 CFR part 1200) on their products because that would unlawfully misrepresent the legal status of the material, and could falsely identify  private organizations as entities of the Federal Government.
 
 #2.Schema Description
 
 The schema chosen to represent the Federal Register is a simplified version of the SGML schema that is used as part of the print production process, with some presentation and print specific tags removed or collapsed, and then converted to well-formed XML. This schema was chosen for the following reasons:
 
-1. It is a complete and faithful representation of the Federal Register, which matches most closely to the author's original intent.&nbsp;
-2. It describes the data using semantic tags in a way that is appropriate to the Federal Register Domain. For example, <RULE>, <NOTICE>, and <AGENCY> are all tags in this schema.&nbsp;
-3. It fully describes the structure of the Federal Register, including the large structure (parts, articles, corrections, table of contents, etc.), the document structure (titles, paragraphs, sections, etc.), and semantic structure (CFR references, agency names, contact information, amendment text, etc.)&nbsp;
+1. It is a complete and faithful representation of the Federal Register, which matches most closely to the author's original intent. 
+2. It describes the data using semantic tags in a way that is appropriate to the Federal Register Domain. For example, <RULE>, <NOTICE>, and <AGENCY> are all tags in this schema. 
+3. It fully describes the structure of the Federal Register, including the large structure (parts, articles, corrections, table of contents, etc.), the document structure (titles, paragraphs, sections, etc.), and semantic structure (CFR references, agency names, contact information, amendment text, etc.) 
 
 Since the schema is not an authoring schema and the SGML to XML conversion process maintains the order of the tags, this allows the XML schema to be more permissive than if it were used for checking authored content.
 
@@ -117,7 +110,7 @@ The schema being produced for this effort describes the data as it actually occu
 
 The following table lists the SGML tags that were removed or collapsed into a source attribute in the Federal Register XML.
 
-&nbsp;
+ 
 
 | Purposed Fields to be Removed | Fields to be Removed or Collapsed | Description |
 | --- | --- | --- |
@@ -128,13 +121,13 @@ The following table lists the SGML tags that were removed or collapsed into a so
 | FNP | Removed | Force new page. |
 | Q | Removed | Inserts vertical spaces |
 | NPAR | Collapse to P | Used to generate a new paragraph where the <P> tag would create a run in entry. |
-| P | Collapse to P | Normally used for paragraph. &nbsp;A paragraph here has the first line indented. |
+| P | Collapse to P | Normally used for paragraph.  A paragraph here has the first line indented. |
 | P1 | Collapse to P | Paragraph, indented one em on left. |
 | P-1 | Collapse to P | Paragraph, turnovers indented one extra em on left. |
 | P1-3 | Collapse to P | Paragraph, indented one em on left, turnovers indented three ems on left. |
 | P2 | Collapse to P | Paragraph, indented two ems on left. |
-| P-2 | Collapse to P | Paragraph, turnovers indented two ems on left. &nbsp;Same as FP1-2, which should not be used. |
-| P2-4 | Collapse to P | Paragraph, indented two ems on left, turnovers indented four &nbsp;ems on left. |
+| P-2 | Collapse to P | Paragraph, turnovers indented two ems on left.  Same as FP1-2, which should not be used. |
+| P2-4 | Collapse to P | Paragraph, indented two ems on left, turnovers indented four  ems on left. |
 | P-3 | Collapse to P | Paragraph, turnovers indented three ems on left. |
 | P-DASH | Collapse to P | Paragraph, the last line of which fills with low-line dashes |
 | OLNOTE1 | Collapse to OLNOTE1 | Sets footnote for first overlay note |
@@ -146,7 +139,7 @@ The following table lists the SGML tags that were removed or collapsed into a so
 | FP | Collapse to FP | Flush paragraph |
 | FP1 | Collapse to FP | Flush paragraph, all lines indented one em. |
 | FP-1 | Collapse to FP | Flush paragraph, turnovers indented one em |
-| FP1-2 | Collapse to FP | Paragraph, first line indented one em and turnovers indented &nbsp;two ems |
+| FP1-2 | Collapse to FP | Paragraph, first line indented one em and turnovers indented  two ems |
 | FP2 | Collapse to FP | Flush paragraph, all lines indented two ems |
 | FP-2 | Collapse to FP | Flush paragraph, turnovers indented two ems |
 | FP2-2 | Collapse to FP | Flush paragraph, all lines indented two ems. |
@@ -163,33 +156,33 @@ The following table lists the SGML tags that were removed or collapsed into a so
 | HD5 | Collapse to HD | Fifth level head in the following sections. |
 | HD6 | Collapse to HD | Sixth level head in the following sections. |
 | HD8 | Collapse to HD | Lowest level head in the following sections. |
-| HED | Collapse to HD | The first head in the following sections. &nbsp; |
+| HED | Collapse to HD | The first head in the following sections.   |
 | HED1 | Collapse to HD | Special first level head in text of Section. |
-| THED &nbsp; &nbsp; &nbsp; | Collapse to HD | Head that turns sideways on the page. |
-| TSECT | Collapse to HD | Section head that turns sideways on the page. &nbsp; |
+| THED       | Collapse to HD | Head that turns sideways on the page. |
+| TSECT | Collapse to HD | Section head that turns sideways on the page.   |
 | FNC | Removed | Used to generate a new column |
 
 ##2.1.Sections Available in XML
 
 The following are currently available in Federal Register XML:
 
-- .Contents&nbsp;
-- .Rules and Regulations&nbsp;
-- .Proposed Rules&nbsp;
-- .Notices&nbsp;
-- .Corrections&nbsp;
+- .Contents 
+- .Rules and Regulations 
+- .Proposed Rules 
+- .Notices 
+- .Corrections 
 
-&nbsp;
+ 
 
 The following are not currently available in Federal Register XML:
 
-- .Front Matter (e.g. cover page)&nbsp;
-- .CFR Parts Affected&nbsp;
-- .Reader Aids&nbsp;
-- .CFR Checklist&nbsp;
-- .CFR Issuances&nbsp;
-- .Table of Effective Dates&nbsp;
-- .Graphics&nbsp;
+- .Front Matter (e.g. cover page) 
+- .CFR Parts Affected 
+- .Reader Aids 
+- .CFR Checklist 
+- .CFR Issuances 
+- .Table of Effective Dates 
+- .Graphics 
 
 ##2.2.Sections, Parts, and Articles
 
@@ -197,15 +190,15 @@ This section describes the top-level structure of a Federal Register XML file.
 
 The XML schema, being a translated reproduction of the SGML schema, contains tags and content in the same order as they appear in the printed document. Major sections are grouped appropriately (<CNTNTS>, <RULES>, <PRORULES>, <NOTICES>, <NEWPART>, <CORRECT>), and all data and tags are represented – with the exception of the reduced tags from the previous section.
 
-&nbsp;
+ 
 
 The XML tags and their descriptions of the schema above are shown below:
 
-&nbsp;
+ 
 
 | XML Tag | Description |
 | --- | --- |
-| FEDREG | The root tag for all document types in Federal Register publications. &nbsp;This tag includes children such as CNTNTS, RULES, PRORULES, NOTICES, NEWPART. &nbsp; |
+| FEDREG | The root tag for all document types in Federal Register publications.  This tag includes children such as CNTNTS, RULES, PRORULES, NOTICES, NEWPART.   |
 | VOL | Contains the volume number for the publication. |
 | NO | Contains the issue number of the volume. |
 | UNITNAME | Contains the display name of the unit which follows, for example, "Notices", "Proposed Rules", "Rules", and "Presidential Documents". |
@@ -217,9 +210,9 @@ The XML tags and their descriptions of the schema above are shown below:
 | NOTICES | Starts Notices section of the Federal Register. Should contain at least one <NOTICE>. |
 | NOTICE | Start individual Notice within Notices section. |
 
-&nbsp;
+ 
 
-&nbsp;
+ 
 
 An abbreviated example of the overall section and structure is below:
 
@@ -269,27 +262,27 @@ An abbreviated example of the overall section and structure is below:
 
 The schema allows for a wide variety XPath commands for extracting items:
 
-&nbsp;//RULE &nbsp; &nbsp;Output all rules
+ //RULE    Output all rules
 
-&nbsp;(//PRTPAGE/@P)[0] &nbsp; &nbsp;Get the first page number
+ (//PRTPAGE/@P)[0]    Get the first page number
 
-&nbsp;(//PRTPAGE/@P)[last()] &nbsp; &nbsp;Get the last page number
+ (//PRTPAGE/@P)[last()]    Get the last page number
 
-&nbsp;//RULE[descendant::PRTPAGE/@P = '12627] &nbsp; &nbsp;Get rule which contains page 12627
+ //RULE[descendant::PRTPAGE/@P = '12627]    Get rule which contains page 12627
 
-&nbsp;//RULE[PREAMB/AGENCY = 'NUCLEAR REGULATORY COMMISSION']
+ //RULE[PREAMB/AGENCY = 'NUCLEAR REGULATORY COMMISSION']
 
-&nbsp;&nbsp; &nbsp;Get all rules for the nuclear regulatory commission
+    Get all rules for the nuclear regulatory commission
 
-&nbsp;
+ 
 
 ##2.3.NEW PART Section 
 
-The NEWPART section holds the contents of a part which often includes a part title and a list of notices, presidential documents, proposed rules, rules, and section names. A part number will always accompany the part title. In some cases, the specified rule will contain a preamble which can contain everything up to, but not including, the supplementary information. &nbsp;
+The NEWPART section holds the contents of a part which often includes a part title and a list of notices, presidential documents, proposed rules, rules, and section names. A part number will always accompany the part title. In some cases, the specified rule will contain a preamble which can contain everything up to, but not including, the supplementary information.  
 
 The XML tags and their descriptions of the schema above are shown below:
 
-&nbsp;
+ 
 
 | XML Tag | Description |
 | --- | --- |
@@ -298,11 +291,11 @@ The XML tags and their descriptions of the schema above are shown below:
 | PARTNO | Sets the part number on title page of new part within volume. |
 | PTITLE | Part title for new part within volume. |
 
-&nbsp;
+ 
 
 An abbreviated example of the NEWPART section and structure is below:
 
-&nbsp;
+ 
 ```
 <FEDREG>
    .
@@ -328,7 +321,7 @@ An abbreviated example of the NEWPART section and structure is below:
 
 The contents of article tags are the ones that usually describe the majority of the data in the Federal Register. For example, XML tags such as HD and P are often used to start the head sentence in the following section while P tag is used to describe the rest of the text. The flush paragraph or FP is used to denote either large or small text depending on where it is being used. In addition, the majority of the sections are also following by Federal Register doc number as well as an agency billing code.
 
-&nbsp;
+ 
 
 | XML Tag | Description |
 | --- | --- |
@@ -340,7 +333,7 @@ The contents of article tags are the ones that usually describe the majority of 
 | BILCOD | Agency billing code number. |
 | EDNOTE | Used for editorial notes. |
 
-&nbsp;
+ 
 
 The contents will roughly have the same structure
 
@@ -385,7 +378,7 @@ The contents will roughly have the same structure
   .
 </FEDREG>
 ```
-&nbsp;
+ 
 
 ##2.5.PREAMBLE Tag
 
@@ -393,13 +386,13 @@ The PREAMBLE can hold contents that describe the current page of the document as
 
 The XML tags and their descriptions of the schema above are shown below:
 
-&nbsp;
+ 
 
 | XML Tag | Description |
 | --- | --- |
 | PREAMB | Used to start the preamble. The preamble contains everything up to but not including the supplementary information. |
 | PRTPAGE | Used to identify the page number in all documents in Federal Register |
-| AGENCY | Used to identify the agency name. &nbsp; |
+| AGENCY | Used to identify the agency name.   |
 | CFR | Used to identify Code of Federal Regulation citation. |
 | RIN | Used to identify regulatory information number. |
 | SUBJECT | Used for title of subject. |
@@ -411,11 +404,11 @@ The XML tags and their descriptions of the schema above are shown below:
 | LSTSUB | Used to start a list of subject section. |
 | REGTEXT | Used to designate regulatory information that will be inserted into the CFR. |
 
-&nbsp;
+ 
 
 An abbreviated example of the PREAMB section and structure is below:
 
-&nbsp;
+ 
 ```
 <RULE>
 
@@ -438,7 +431,7 @@ An abbreviated example of the PREAMB section and structure is below:
   <BILCOD>BILLING CODE 7590-01-P</BILCOD>
 </RULE>
 ```
-&nbsp;
+ 
 
 ##2.6.SUPLINF Tag
 
@@ -446,7 +439,7 @@ The SUPLINF tag holds supplementary information that describes Federal Register 
 
 The XML tags and their descriptions of the SUPLINF schema are shown below.
 
-&nbsp;
+ 
 
 | XML Tag | Description |
 | --- | --- |
@@ -454,11 +447,11 @@ The XML tags and their descriptions of the SUPLINF schema are shown below.
 | LSTSUB | Used to start a list of subject section. |
 | REGTEXT | Used to designate regulatory information that will be inserted into the CFR. |
 
-&nbsp;
+ 
 
 An abbreviated example of the SUPLINF section and structure is below:
 
-&nbsp;
+ 
 ```
 <RULE>
 ...
@@ -475,7 +468,7 @@ An abbreviated example of the SUPLINF section and structure is below:
 ...
 </RULE>
 ```
-&nbsp;
+ 
 
 ##2.7.Presidential Documents
 
@@ -483,7 +476,7 @@ The PRESDOCS tag must have one or more presidential documents which may include 
 
 The XML tags and their descriptions of the schema above are shown below:
 
-&nbsp;
+ 
 
 | Node | Description |
 | --- | --- |
@@ -499,11 +492,11 @@ The XML tags and their descriptions of the schema above are shown below:
 | TITLE3 | CFR Title for Presidential documents. |
 | PSIG | President associated with a Presidential document. |
 | PLACE | Place of issuance for a Presidential document. |
-| DATE | Date associated with the Presidential document. &nbsp; |
+| DATE | Date associated with the Presidential document.   |
 
 An abbreviated example of the PRESDOCS section and structure is below:
 
-&nbsp;
+ 
 ```
 <FEDREG>
 ...  
@@ -536,8 +529,8 @@ An abbreviated example of the PRESDOCS section and structure is below:
 ...
 </FEDREG>
 ```
-&nbsp;
+ 
 
 #3.Resources Directory
 
-The resources directory in the Federal Register bulk data repository at [http://www.gpo.gov/fdsys/bulkdata/FR/resources](http://www.gpo.gov/fdsys/bulkdata/FR/resources) contains the current version of the XML schema, the XML stylesheet used to display the XML files in a browser on the FDsys website, and this user guide in PDF.
+The resources directory in the _Federal Register_ bulk data repository at [http://www.gpo.gov/fdsys/bulkdata/FR/resources](http://www.gpo.gov/fdsys/bulkdata/FR/resources) contains the current version of the XML schema, the XML stylesheet used to display the XML files in a browser on the FDsys website, and this user guide in PDF.

--- a/FR-XML_User-Guide.md
+++ b/FR-XML_User-Guide.md
@@ -1,0 +1,543 @@
+#Federal Digital System (FDsys) User Guide
+
+##Federal Register XML Rendition 
+
+Prepared by:Office of Programs, Strategy, and Technology
+
+Office of the Chief Technology Officer  
+U.S. Government Publishing Office
+&nbsp;
+
+##Revision History
+
+- 1.0 September 2009
+  Initial publication
+- 1.1 March 2015
+  Markdown version
+
+#1.Introduction
+
+The U.S. Government Printing Office (GPO) and the National Archives' Office of the Federal Register (OFR) partnership is offering bulk data downloads of Federal Register files to the general public via Data.gov and FDsys. &nbsp;This effort began when the President challenged Federal agencies to create a more open and transparent government, promote accountability, and provide information to citizens about what their Government is doing (see 74 FR 4685, January 26, 2009 at [http://www.gpo.gov/fdsys/pkg/FR-2009-01-26/pdf/E9-1777.pdf](http://www.gpo.gov/fdsys/pkg/FR-2009-01-26/pdf/E9-1777.pdf)). &nbsp;The Public Printer's letter of March 9, 2009 pledged to provide trusted information in whatever form is required to meet the President's objectives [http://www.gpo.gov/pdfs/news-media/letter\_030909.pdf](http://www.gpo.gov/pdfs/news-media/letter_030909.pdf). &nbsp;
+
+&nbsp;
+
+In addition, the Office of the Federal Register coordinates with the Office of Science Technology Policy to ensure that the OFR/GPO partnership meets customer expectations. &nbsp; To follow through on our commitment, we are expanding and accelerating the development of FDsys to provide XML-structured content as rendered output. &nbsp;This will give users access to masses of data to reconfigure and redistribute as they wish to meet the specialized needs of their constituencies. &nbsp;
+
+##1.1.Purpose
+
+The purpose of this document is to provide an overview of Federal Register XML files and associated schema. The FDsys Bulk Data repository at [http://www.gpo.gov/fdsys/bulkdata/](http://www.gpo.gov/fdsys/bulkdata/) contains the Federal Register in XML from 2000 to the present. Please see FDsys at [www.fdsys.gov](http://www.fdsys.gov/) for access to the Federal Register in PDF and HTML formats. &nbsp;
+
+##1.2.Legal Status & Authenticity of Federal Register files via Data.gov
+
+&nbsp;
+
+**Q. What is the data set available for the Federal Register in XML?**
+
+&nbsp;
+
+**A. &nbsp; &nbsp; &nbsp; &nbsp;** Federal Register files in XML have been converted and simplified from the SGML rendition used for the printed publication. The Federal Register is available in XML starting with the year 2000, when GPO began composing Federal Register material in SGML. OFR/GPO plan to convert the remaining electronic data set for the Federal Register (1994-1999) at a future date.
+
+&nbsp;
+
+**Q. &nbsp;Are bulk data downloads of XML files offered on FDsys via Data.gov part of the official version of the _Federal Register_?**
+
+&nbsp;
+
+**A.** &nbsp;No, the XML-structured files offered for bulk download are not part of the official on-line format of the _Federal Register_. While GPO's XML files are based on the original source data submitted by Federal agencies, OFR markup, and GPO typesetting and composition markup in SGML, only the PDF and Text versions of _Federal Register _content on GPO Access and FDsys have legal status as parts of the official online format of the _Federal Register_. &nbsp;Additional development will be required before OFR/GPO can specify that XML files are a part of the official online edition of the _Federal Register_. &nbsp;
+
+&nbsp;
+
+**Q. &nbsp;Do OFR/GPO plan to include XML files as part of the official format of the Federal Register?**
+
+&nbsp;
+
+**A.** &nbsp;Yes. The current set of XML-structured material (minus graphics) is not yet characterized as part of the official online _Federal Register _format because the underlying data used to create a viewable rendition of the material must be thoroughly scrutinized and tested. The XML-structured files are derived from SGML-tagged data and printing codes, which may produce anomalies in display. &nbsp;For example, complex tabular material in XML files may not display as correctly composed objects equivalent to the tables that appear in the Text and PDF files. &nbsp;Tabular material that displays in an ambiguous or distorted manner could affect the substantive meaning of regulations and other documents. &nbsp;
+
+&nbsp;
+
+Our goal is to clean up the XML data and develop associated style sheets to the point that the XML rendition can be characterized as a display format of the official online edition. &nbsp;We are also developing the means to embed graphics in the files, so that an XML version may be deemed both official and complete. &nbsp;The OFR will issue a _Federal Register Bulletin_ to alert users when the XML-structured files are ready to be included as part of the official online edition. &nbsp;
+
+**Q. &nbsp;What is the legal basis for making determinations about official status?**
+
+**A.** &nbsp;The Federal Register Act established the Administrative Committee of the Federal Register (Administrative Committee or ACFR) as the regulatory body with authority to determine the format(s) of the official serial publication known as the _Federal Register _(44 U.S.C. Ch. 15). Under 1 CFR 5.10, the official formats approved by the ACFR include a paper edition, a microfiche edition, and an online edition. &nbsp;OFR and GPO carry out ACFR regulations by developing appropriate means to display Federal Register material in the official formats. &nbsp;
+
+&nbsp;
+
+Q. When did the Federal Register first appear online?
+
+&nbsp;
+
+**A.** The official online edition dates to 1994 when Congress authorized an online edition in Public Law 103-40 (the Government Printing Office Electronic Information Enhancement Act of 1993; codified at 44 U.S.C. 4101). &nbsp;
+
+&nbsp;
+
+Q. &nbsp;Are Federal Register XML bulk download files digitally signed?
+
+No, XML files available for download are not digitally signed. &nbsp;They can be manipulated and enriched to operate in the various applications that users may devise. GPO is evaluating technology that could be used to digitally sign XML files for future official editions posted on FDsys. &nbsp;Adding signed non-PDF files to FDsys would be an enhancement for FDsys users, but would not be used to restrict or adversely affect the XML bulk data downloads available to our customers. &nbsp;
+
+**Q. &nbsp;What does the term "digitally signed" mean?**
+
+&nbsp;
+
+**A**. Currently, GPO uses digital signature technology on PDF documents to add a visible Seal of Authenticity (a graphic of an eagle) to authenticated and certified documents. The technology allows GPO to secure data integrity, and provide users with assurance that the content is unchanged since it was disseminated by GPO. A signed and certified document also displays a blue ribbon icon to the left of the Seal of Authenticity and in the Signatures tab within Adobe Acrobat or Reader. When users print a document that has been signed and certified by GPO, the Seal of Authenticity will automatically print on the document, but the blue ribbon will not print.
+
+**Q. How reliable is the metadata and the underlying tagging in bulk data files?**
+
+**A.** &nbsp;The document markup and metadata found within bulk data files are generally reliable and complete. &nbsp;However, there are variations in this underlying data due to inconsistencies in the composition and typesetting process. &nbsp;As a result, some data-mining applications and user aids may not produce 100 per cent accurate results. &nbsp;
+
+Q. &nbsp;What is the legal status of Federal Register user aids?
+
+**A.:** Federal Register user aids, including, finding aids, indexes, search tools, metadata associations, and tagging schemes are not part of the legal text of the _Federal Register_. &nbsp;These ancillary features help users explore and extract data, but the official legal text stands on its own. &nbsp;No person should form absolute legal conclusions based on search results, finding aids, metadata associations, extractions of data, and the like. &nbsp;Ultimately, only the official text of the _Federal Register_ may be relied upon as evidence in a court of law. &nbsp;
+
+**Q. &nbsp;What is the authenticity of Federal Register bulk data files after they have been downloaded to another site? &nbsp;**
+
+**A.** &nbsp; We cannot vouch for the authenticity of data that is not under OFR/GPO control. OFR and GPO are providing free access to Federal Register data via XML for display in various applications and mash-ups outside the FDsys domain. &nbsp;The OFR/GPO partnership does not endorse third party applications, and does not evaluate how our original legal content is displayed on other sites. &nbsp;Consumers should form their own conclusions as to whether the downloaded data can be relied upon within an application or mash-up. &nbsp;An application may link to the official _Federal Register_ on FDsys to provide users with additional assurance. &nbsp;
+
+**Q. Do OFR and GPO assert any control over downstream uses of bulk data?**
+
+**A.** &nbsp;In general, there are no restrictions on re-use of information in Federal Register documents because U.S. Government works are not subject to copyright. OFR and GPO do not restrict downstream uses of Federal Register data, except that independent providers should be aware that only the OFR and GPO are entitled to represent that they are the providers of the official versions of the _Federal Register_ and related Federal Register publications. &nbsp;
+
+&nbsp;
+
+Q. How can re-publishers indicate the source of Federal Register data?
+
+**A**. Re-publishers of Federal Register data may cite FDsys and OFR/GPO as the source of their data, and they are free to characterize the quality of data as it appears on their site. But private sector re-publishers are prohibited from using the seal of the National Archives and Records Administration (NARA) or stylized Federal Register logos identified in NARA regulations (36 CFR part 1200) on their products because that would unlawfully misrepresent the legal status of the material, and could falsely identify &nbsp;private organizations as entities of the Federal Government.
+
+#2.Schema Description
+
+The schema chosen to represent the Federal Register is a simplified version of the SGML schema that is used as part of the print production process, with some presentation and print specific tags removed or collapsed, and then converted to well-formed XML. This schema was chosen for the following reasons:
+
+1. It is a complete and faithful representation of the Federal Register, which matches most closely to the author's original intent.&nbsp;
+2. It describes the data using semantic tags in a way that is appropriate to the Federal Register Domain. For example, <RULE>, <NOTICE>, and <AGENCY> are all tags in this schema.&nbsp;
+3. It fully describes the structure of the Federal Register, including the large structure (parts, articles, corrections, table of contents, etc.), the document structure (titles, paragraphs, sections, etc.), and semantic structure (CFR references, agency names, contact information, amendment text, etc.)&nbsp;
+
+Since the schema is not an authoring schema and the SGML to XML conversion process maintains the order of the tags, this allows the XML schema to be more permissive than if it were used for checking authored content.
+
+The schema being produced for this effort describes the data as it actually occurs from the OFR. Documents are not being cleaned up because they do not match the schema; instead, the schema was selectively relaxed. Such an approach maintains 100% fidelity to the original data, and eliminates any errors that might occur in schema interpretation or further data manipulation.
+
+The following table lists the SGML tags that were removed or collapsed into a source attribute in the Federal Register XML.
+
+&nbsp;
+
+| Purposed Fields to be Removed | Fields to be Removed or Collapsed | Description |
+| --- | --- | --- |
+| EDITOR | Removed | Used to indicate content editor |
+| FNC | Removed | Used to generate a new column |
+| FNEP | Removed | Used to generate a new even page |
+| FNOP | Removed | Used to generate a new odd page. |
+| FNP | Removed | Force new page. |
+| Q | Removed | Inserts vertical spaces |
+| NPAR | Collapse to P | Used to generate a new paragraph where the <P> tag would create a run in entry. |
+| P | Collapse to P | Normally used for paragraph. &nbsp;A paragraph here has the first line indented. |
+| P1 | Collapse to P | Paragraph, indented one em on left. |
+| P-1 | Collapse to P | Paragraph, turnovers indented one extra em on left. |
+| P1-3 | Collapse to P | Paragraph, indented one em on left, turnovers indented three ems on left. |
+| P2 | Collapse to P | Paragraph, indented two ems on left. |
+| P-2 | Collapse to P | Paragraph, turnovers indented two ems on left. &nbsp;Same as FP1-2, which should not be used. |
+| P2-4 | Collapse to P | Paragraph, indented two ems on left, turnovers indented four &nbsp;ems on left. |
+| P-3 | Collapse to P | Paragraph, turnovers indented three ems on left. |
+| P-DASH | Collapse to P | Paragraph, the last line of which fills with low-line dashes |
+| OLNOTE1 | Collapse to OLNOTE1 | Sets footnote for first overlay note |
+| OLNOTE2 | Collapse to OLNOTE1 | Sets footnote for second overlay note. |
+| OLNOTE3 | Collapse to OLNOTE1 | Sets footnote for third overlay note. |
+| OLNOTE4 | Collapse to OLNOTE1 | Sets footnote for fourth overlay note. |
+| OLNOTE5 | Collapse to OLNOTE1 | Sets footnote for fifth overlay note. |
+| OLNOTE6 | Collapse to OLNOTE1 | Sets footnote for sixth overlay note. |
+| FP | Collapse to FP | Flush paragraph |
+| FP1 | Collapse to FP | Flush paragraph, all lines indented one em. |
+| FP-1 | Collapse to FP | Flush paragraph, turnovers indented one em |
+| FP1-2 | Collapse to FP | Paragraph, first line indented one em and turnovers indented &nbsp;two ems |
+| FP2 | Collapse to FP | Flush paragraph, all lines indented two ems |
+| FP-2 | Collapse to FP | Flush paragraph, turnovers indented two ems |
+| FP2-2 | Collapse to FP | Flush paragraph, all lines indented two ems. |
+| FP2-3 | Collapse to FP | Paragraph, first line indented two ems and turnovers indented three ems |
+| FP3 | Collapse to FP | Flush paragraph, all lines indented three ems. |
+| FP-DASH | Collapse to FP | Flush line that fills with low-line dashes. |
+| FRP | Collapse to FP | Flush right material, actually held in 1 em from right margin |
+| FRP0 | Collapse to FP | True flush right material |
+| HD | Collapse to HD | First level head in the following sections. |
+| HD1 | Collapse to HD | First level head in the following sections. |
+| HD2 | Collapse to HD | Second level head in the following sections. |
+| HD3 | Collapse to HD | Third level head in the following sections. |
+| HD4 | Collapse to HD | Fourth level head in the following sections. |
+| HD5 | Collapse to HD | Fifth level head in the following sections. |
+| HD6 | Collapse to HD | Sixth level head in the following sections. |
+| HD8 | Collapse to HD | Lowest level head in the following sections. |
+| HED | Collapse to HD | The first head in the following sections. &nbsp; |
+| HED1 | Collapse to HD | Special first level head in text of Section. |
+| THED &nbsp; &nbsp; &nbsp; | Collapse to HD | Head that turns sideways on the page. |
+| TSECT | Collapse to HD | Section head that turns sideways on the page. &nbsp; |
+| FNC | Removed | Used to generate a new column |
+
+##2.1.Sections Available in XML
+
+The following are currently available in Federal Register XML:
+
+- .Contents&nbsp;
+- .Rules and Regulations&nbsp;
+- .Proposed Rules&nbsp;
+- .Notices&nbsp;
+- .Corrections&nbsp;
+
+&nbsp;
+
+The following are not currently available in Federal Register XML:
+
+- .Front Matter (e.g. cover page)&nbsp;
+- .CFR Parts Affected&nbsp;
+- .Reader Aids&nbsp;
+- .CFR Checklist&nbsp;
+- .CFR Issuances&nbsp;
+- .Table of Effective Dates&nbsp;
+- .Graphics&nbsp;
+
+##2.2.Sections, Parts, and Articles
+
+This section describes the top-level structure of a Federal Register XML file.
+
+The XML schema, being a translated reproduction of the SGML schema, contains tags and content in the same order as they appear in the printed document. Major sections are grouped appropriately (<CNTNTS>, <RULES>, <PRORULES>, <NOTICES>, <NEWPART>, <CORRECT>), and all data and tags are represented – with the exception of the reduced tags from the previous section.
+
+&nbsp;
+
+The XML tags and their descriptions of the schema above are shown below:
+
+&nbsp;
+
+| XML Tag | Description |
+| --- | --- |
+| FEDREG | The root tag for all document types in Federal Register publications. &nbsp;This tag includes children such as CNTNTS, RULES, PRORULES, NOTICES, NEWPART. &nbsp; |
+| VOL | Contains the volume number for the publication. |
+| NO | Contains the issue number of the volume. |
+| UNITNAME | Contains the display name of the unit which follows, for example, "Notices", "Proposed Rules", "Rules", and "Presidential Documents". |
+| CNTNTS | Contains table of contents pages for the Federal Register. |
+| RULES | Used to start Rules section of the federal register. RULES may contain at least one <RULE>. |
+| RULE | Used to start individual Rules in the Rules section. |
+| PRORULES | Used to start Proposed Rules section of the Federal Register. Should contain at least one <PRORULE>. |
+| PRORULE | Used to start individual Proposed Rule of the Federal Register. |
+| NOTICES | Starts Notices section of the Federal Register. Should contain at least one <NOTICE>. |
+| NOTICE | Start individual Notice within Notices section. |
+
+&nbsp;
+
+&nbsp;
+
+An abbreviated example of the overall section and structure is below:
+
+ 
+
+<FEDREG>
+
+  <VOL>65</VOL>
+  <NO>21</NO>
+  <UNITNAME>Contents</UNITNAME>
+  <CNTNTS>
+    ... THE CONTENTS OF THE TABLE OF CONTENTS ...
+  </CNTNTS>
+  <DATE>Tuesday, February 1, 2000 1-3-00</DATE>
+  <UNITNAME>Rules and Regulations</UNITNAME>
+  <RULES>
+    <RULE>  ... THE CONTENTS OF THE RULE ... </RULE>
+    .
+    .
+    .
+  </RULES>
+  <UNITNAME>Proposed Rules</UNITNAME>
+  <PRORULES>
+    <PRORULE>  ... THE CONTENTS OF THE PROPOSED RULE ... </PRORULE>
+    .
+    .
+    .
+  </PRORULES>
+  <UNITNAME>Notices</UNITNAME>
+  <NOTICES>
+    <NOTICE>  ... THE CONTENTS OF THE NOTICE ... </NOTICE>
+    .
+    .
+    .
+  </NOTICES>
+  <NEWPART>
+       ... THE CONTENTS OF THE PART ...
+  </NEWPART>
+  .
+  .
+  .
+
+</FEDREG>
+
+###2.2.1.XPath Examples
+
+The schema allows for a wide variety XPath commands for extracting items:
+
+&nbsp;//RULE &nbsp; &nbsp;Output all rules
+
+&nbsp;(//PRTPAGE/@P)[0] &nbsp; &nbsp;Get the first page number
+
+&nbsp;(//PRTPAGE/@P)[last()] &nbsp; &nbsp;Get the last page number
+
+&nbsp;//RULE[descendant::PRTPAGE/@P = '12627] &nbsp; &nbsp;Get rule which contains page 12627
+
+&nbsp;//RULE[PREAMB/AGENCY = 'NUCLEAR REGULATORY COMMISSION']
+
+&nbsp;&nbsp; &nbsp;Get all rules for the nuclear regulatory commission
+
+&nbsp;
+
+##2.3.NEW PART Section 
+
+The NEWPART section holds the contents of a part which often includes a part title and a list of notices, presidential documents, proposed rules, rules, and section names. A part number will always accompany the part title. In some cases, the specified rule will contain a preamble which can contain everything up to, but not including, the supplementary information. &nbsp;
+
+The XML tags and their descriptions of the schema above are shown below:
+
+&nbsp;
+
+| XML Tag | Description |
+| --- | --- |
+| NEWPART | Used to start a new part of the Federal Register. |
+| PART | Part group or container tag for search and retrieval purposes. |
+| PARTNO | Sets the part number on title page of new part within volume. |
+| PTITLE | Part title for new part within volume. |
+
+&nbsp;
+
+An abbreviated example of the NEWPART section and structure is below:
+
+&nbsp;
+
+<FEDREG>
+   .
+   .
+   .
+  <NEWPART>
+    <PTITLE>
+      <PRTPAGE P="47239"/>
+      <PARTNO>Part IV</PARTNO>
+      <PRES>The President</PRES>
+      <PNOTICE>Notice of July 28, 2000—Continuation of Emergency</PNOTICE>
+    </PTITLE>
+    <PRESDOCS>
+      .
+      .
+      .
+    </PRESDOCS>
+  </NEWPART>
+</FEDREG>
+
+##2.4.The Contents of Article
+
+The contents of article tags are the ones that usually describe the majority of the data in the Federal Register. For example, XML tags such as HD and P are often used to start the head sentence in the following section while P tag is used to describe the rest of the text. The flush paragraph or FP is used to denote either large or small text depending on where it is being used. In addition, the majority of the sections are also following by Federal Register doc number as well as an agency billing code.
+
+&nbsp;
+
+| XML Tag | Description |
+| --- | --- |
+| HD | Used to start a new part of the Federal Register. |
+| P | Part group or container tag for search and retrieval purposes. |
+| DATES | Used to describe dates such as effective, applicable, and comment dates. |
+| FP | Flush paragraph. |
+| FRDOC | Federal Register doc number. It is used to track when entries were submitted for publication. |
+| BILCOD | Agency billing code number. |
+| EDNOTE | Used for editorial notes. |
+
+&nbsp;
+
+The contents will roughly have the same structure
+
+ 
+
+<FEDREG>
+
+   .
+   .
+   .
+  <CNTNTS>
+    ...
+    <AGCY>
+      <HD>Agricultural Marketing Service</HD>
+      ...
+      <SEE>
+        ...
+        <P>Farm Service Agency</P>
+        ...
+      </SEE>
+      ...
+    </AGCY>
+     ...
+ </CNTNTS>
+   .
+   .
+   .
+  <RULES>
+    <RULE>
+      .
+      .
+      .
+      <EDNOTE>
+        <FP>The Farm Service has...</FP>
+      </EDNOTE>
+      <DATE>December 4, 2000.</DATE>
+      <FRDOC>[FR Doc. 00-31252]</FRDOC>
+      <BILCOD>File 12-5-00; 8:45 am </BILCOD>
+    </RULE>
+  </RULES>
+  .
+  .
+  .
+</FEDREG>
+
+&nbsp;
+
+##2.5.PREAMBLE Tag
+
+The PREAMBLE can hold contents that describe the current page of the document as well as agencies, sub agencies, actions, summaries, RIN numbers, and CFR citations. In general, a preamble tag can hold everything up to but not including the supplementary information. To view a complete list of valid fields, please see the XSD schema.
+
+The XML tags and their descriptions of the schema above are shown below:
+
+&nbsp;
+
+| XML Tag | Description |
+| --- | --- |
+| PREAMB | Used to start the preamble. The preamble contains everything up to but not including the supplementary information. |
+| PRTPAGE | Used to identify the page number in all documents in Federal Register |
+| AGENCY | Used to identify the agency name. &nbsp; |
+| CFR | Used to identify Code of Federal Regulation citation. |
+| RIN | Used to identify regulatory information number. |
+| SUBJECT | Used for title of subject. |
+| ACT | Used to identify an action. |
+| SUM | Used to identify a summary. |
+| ADD | Used to describe contact addresses. |
+| FURINF | Used to describe "FOR FURTHER INFORMATION CONTACT:". |
+| SUPLINF | Used to describe supplementary information. |
+| LSTSUB | Used to start a list of subject section. |
+| REGTEXT | Used to designate regulatory information that will be inserted into the CFR. |
+
+&nbsp;
+
+An abbreviated example of the PREAMB section and structure is below:
+
+&nbsp;
+
+<RULE>
+
+  <PREAMB>
+    <PRTPAGE P="12627"/>
+    <AGENCY TYPE="F">NUCLEAR REGULATORY COMMISSION</AGENCY>
+    <CFR>10 CFR Part 2</CFR>
+    <RIN>RIN 3150-AI08</RIN>
+    <SUBJECT>Interlocutory Review of Rulings on Requests...</SUBJECT>
+    <ACT><HD SOURCE="HED">ACTION:</HD><P>Final rule.</P></ACT>
+    <SUM>  ... the summary of the rule ... </SUM>
+    <DATES>  .... Description of effective or applicable dates ... </DATES>
+    <ADD>  ... contact addresses ... </ADD>
+    <FURINF> ... where to go for further information about rule ... </FURINF>
+  </PREAMB>
+    .
+    .
+    .
+  <FRDOC>[FR Doc. E8-4768 Filed 3-7-08; 8:45 am]</FRDOC>
+  <BILCOD>BILLING CODE 7590-01-P</BILCOD>
+</RULE>
+
+&nbsp;
+
+##2.6.SUPLINF Tag
+
+The SUPLINF tag holds supplementary information that describes Federal Register documents. This information may include the page number, list of subjects or regulatory text material from the Rules section. The list of subjects will also include a list of CFR numbers cited in the appropriate rules.
+
+The XML tags and their descriptions of the SUPLINF schema are shown below.
+
+&nbsp;
+
+| XML Tag | Description |
+| --- | --- |
+| SUPLINF | Used to describe supplementary information. |
+| LSTSUB | Used to start a list of subject section. |
+| REGTEXT | Used to designate regulatory information that will be inserted into the CFR. |
+
+&nbsp;
+
+An abbreviated example of the SUPLINF section and structure is below:
+
+&nbsp;
+
+<RULE>
+...
+<SUPLINF>
+    ... Supplementary information ...
+    <LSTSUB>  ... List of CFR subjects appropriate to the rule ... </LSTSUB>
+    <REGTEXT PART="2" TITLE="10">
+        ... Specific changes to the CFR (Title 10, Part 2 in this example) ...
+    </REGTEXT>
+    .
+    .
+    .
+  </SUPLINF>
+...
+</RULE>
+&nbsp;
+
+##2.7.Presidential Documents
+
+The PRESDOCS tag must have one or more presidential documents which may include determinations, executive orders, memos, notices, or proclamations. A presidential notice, for example, will often have a title and presidential signature associated with it. It may also include the place of issuance which is usually "The White House." These items are always followed by Federal Register doc number, the date filed, and the billing code.
+
+The XML tags and their descriptions of the schema above are shown below:
+
+&nbsp;
+
+| Node | Description |
+| --- | --- |
+| PRESDOCS | Used to start presidential documents section of the Federal Register. |
+| PRESDOCU | Used to start individual Presidential document in the Federal Register. |
+| PRESDOC | Used to start individual Presidential documents section of the Federal Register. |
+| PRNOTICE | Notice of the Presidential documents. |
+| DETERM | Presidential determination in Presidential documents. |
+| EXECORD | Presidential Executive Order in Presidential documents. |
+| PRMEMO | Presidential Memo in presidential documents. |
+| PRORDER | Presidential Order in Presidential documents. |
+| PNOTICE | Notice in Presidential documents. |
+| TITLE3 | CFR Title for Presidential documents. |
+| PSIG | President associated with a Presidential document. |
+| PLACE | Place of issuance for a Presidential document. |
+| DATE | Date associated with the Presidential document. &nbsp; |
+
+An abbreviated example of the PRESDOCS section and structure is below:
+
+&nbsp;
+
+<FEDREG>
+...  
+  <NEWPART>
+    <PTITLE>
+      <PRTPAGE P="47239"/>
+      <PARTNO>Part IV</PARTNO>
+      <PRES>The President</PRES>
+      <PNOTICE>Notice of July 28, 2000—Continuation… </PNOTICE>
+    </PTITLE>
+    <PRESDOCS>
+      <PRESDOCU>
+        <PRNOTICE>
+          <TITLE3>Title 3—</TITLE3>
+          <PRES>The President<PRTPAGE P="47241"/></PRES>
+          <PNOTICE>Notice of July 28, 2000</PNOTICE>
+          <HD SOURCE="HED">Continuation of Iraqi Emergency</HD>
+          <FP>On August 2, 1990, by Executive Order 12722…</FP>
+          <FP>This notice shall …<E T="04">Federal Register</E>…and…</FP>
+          <PSIG>wj</PSIG>
+          <PLACE>THE WHITE HOUSE,</PLACE>
+          <DATE>July 28, 2000.</DATE>
+          <FRDOC>[FR Doc. 00-19587</FRDOC>
+          <FILED>Filed 7-31-00; 8:45 am]</FILED>
+          <BILCOD>Billing code 3195-01-P</BILCOD>
+        </PRNOTICE>
+      </PRESDOCU>
+    </PRESDOCS>
+  </NEWPART>
+...
+</FEDREG>
+
+&nbsp;
+
+&nbsp;
+
+#3.Resources Directory
+
+The resources directory in the Federal Register bulk data repository at [http://www.gpo.gov/fdsys/bulkdata/FR/resources](http://www.gpo.gov/fdsys/bulkdata/FR/resources) contains the current version of the XML schema, the XML stylesheet used to display the XML files in a browser on the FDsys website, and this user guide in PDF.

--- a/FR-XML_User-Guide.md
+++ b/FR-XML_User-Guide.md
@@ -32,49 +32,61 @@ The purpose of this document is to provide an overview of Federal Register XML f
  
 
 **Q. What is the data set available for the Federal Register in XML?**
+
 **A.** Federal Register files in XML have been converted and simplified from the SGML rendition used for the printed publication. The Federal Register is available in XML starting with the year 2000, when GPO began composing Federal Register material in SGML. OFR/GPO plan to convert the remaining electronic data set for the _Federal Register_ (1994-1999) at a future date.
 
  
 **Q.  Are bulk data downloads of XML files offered on FDsys via Data.gov part of the official version of the _Federal Register_?**
+
 **A.**  No, the XML-structured files offered for bulk download are not part of the official on-line format of the _Federal Register_. While GPO's XML files are based on the original source data submitted by Federal agencies, OFR markup, and GPO typesetting and composition markup in SGML, only the PDF and Text versions of _Federal Register_ content on GPO Access and FDsys have legal status as parts of the official online format of the _Federal Register_.  Additional development will be required before OFR/GPO can specify that XML files are a part of the official online edition of the _Federal Register_.  
  
 
 **Q.  Do OFR/GPO plan to include XML files as part of the official format of the Federal Register?**
+
 **A.**  Yes. The current set of XML-structured material (minus graphics) is not yet characterized as part of the official online _Federal Register_ format because the underlying data used to create a viewable rendition of the material must be thoroughly scrutinized and tested. The XML-structured files are derived from SGML-tagged data and printing codes, which may produce anomalies in display.  For example, complex tabular material in XML files may not display as correctly composed objects equivalent to the tables that appear in the Text and PDF files.  Tabular material that displays in an ambiguous or distorted manner could affect the substantive meaning of regulations and other documents.  
 Our goal is to clean up the XML data and develop associated style sheets to the point that the XML rendition can be characterized as a display format of the official online edition.  We are also developing the means to embed graphics in the files, so that an XML version may be deemed both official and complete.  The OFR will issue a _Federal Register Bulletin_ to alert users when the XML-structured files are ready to be included as part of the official online edition.  
 
 
 **Q.  What is the legal basis for making determinations about official status?**
+
 **A.**  The Federal Register Act established the Administrative Committee of the Federal Register (Administrative Committee or ACFR) as the regulatory body with authority to determine the format(s) of the official serial publication known as the _Federal Register _(44 U.S.C. Ch. 15). Under 1 CFR 5.10, the official formats approved by the ACFR include a paper edition, a microfiche edition, and an online edition.  OFR and GPO carry out ACFR regulations by developing appropriate means to display Federal Register material in the official formats.  
 
 
 **Q. When did the Federal Register first appear online?**
+
 **A.** The official online edition dates to 1994 when Congress authorized an online edition in Public Law 103-40 (the Government Printing Office Electronic Information Enhancement Act of 1993; codified at 44 U.S.C. 4101).  
 
 
 **Q.  Are Federal Register XML bulk download files digitally signed?**
+
 **A.** No, XML files available for download are not digitally signed.  They can be manipulated and enriched to operate in the various applications that users may devise. GPO is evaluating technology that could be used to digitally sign XML files for future official editions posted on FDsys.  Adding signed non-PDF files to FDsys would be an enhancement for FDsys users, but would not be used to restrict or adversely affect the XML bulk data downloads available to our customers.  
 
 
 **Q.  What does the term "digitally signed" mean?**
+
 **A**. Currently, GPO uses digital signature technology on PDF documents to add a visible Seal of Authenticity (a graphic of an eagle) to authenticated and certified documents. The technology allows GPO to secure data integrity, and provide users with assurance that the content is unchanged since it was disseminated by GPO. A signed and certified document also displays a blue ribbon icon to the left of the Seal of Authenticity and in the Signatures tab within Adobe Acrobat or Reader. When users print a document that has been signed and certified by GPO, the Seal of Authenticity will automatically print on the document, but the blue ribbon will not print.
 
 
 **Q. How reliable is the metadata and the underlying tagging in bulk data files?**
+
 **A.**  The document markup and metadata found within bulk data files are generally reliable and complete.  However, there are variations in this underlying data due to inconsistencies in the composition and typesetting process.  As a result, some data-mining applications and user aids may not produce 100 per cent accurate results.  
 
 
 **Q.  What is the legal status of Federal Register user aids?**
+
 **A.** Federal Register user aids, including, finding aids, indexes, search tools, metadata associations, and tagging schemes are not part of the legal text of the _Federal Register_.  These ancillary features help users explore and extract data, but the official legal text stands on its own.  No person should form absolute legal conclusions based on search results, finding aids, metadata associations, extractions of data, and the like.  Ultimately, only the official text of the _Federal Register_ may be relied upon as evidence in a court of law.  
 
 
-**Q.  What is the authenticity of Federal Register bulk data files after they have been downloaded to another site?  **
+**Q.  What is the authenticity of Federal Register bulk data files after they have been downloaded to another site?**
+
 **A.**   We cannot vouch for the authenticity of data that is not under OFR/GPO control. OFR and GPO are providing free access to Federal Register data via XML for display in various applications and mash-ups outside the FDsys domain.  The OFR/GPO partnership does not endorse third party applications, and does not evaluate how our original legal content is displayed on other sites.  Consumers should form their own conclusions as to whether the downloaded data can be relied upon within an application or mash-up.  An application may link to the official _Federal Register_ on FDsys to provide users with additional assurance.  
 
 **Q. Do OFR and GPO assert any control over downstream uses of bulk data?**
+
 **A.**  In general, there are no restrictions on re-use of information in Federal Register documents because U.S. Government works are not subject to copyright. OFR and GPO do not restrict downstream uses of Federal Register data, except that independent providers should be aware that only the OFR and GPO are entitled to represent that they are the providers of the official versions of the _Federal Register_ and related Federal Register publications.  
 
 **Q. How can re-publishers indicate the source of Federal Register data?**
+
 **A.** Re-publishers of Federal Register data may cite FDsys and OFR/GPO as the source of their data, and they are free to characterize the quality of data as it appears on their site. But private sector re-publishers are prohibited from using the seal of the National Archives and Records Administration (NARA) or stylized Federal Register logos identified in NARA regulations (36 CFR part 1200) on their products because that would unlawfully misrepresent the legal status of the material, and could falsely identify  private organizations as entities of the Federal Government.
 
 

--- a/FR-XML_User-Guide.md
+++ b/FR-XML_User-Guide.md
@@ -27,74 +27,56 @@ In addition, the Office of the Federal Register coordinates with the Office of S
 
 The purpose of this document is to provide an overview of Federal Register XML files and associated schema. The FDsys Bulk Data repository at [http://www.gpo.gov/fdsys/bulkdata/](http://www.gpo.gov/fdsys/bulkdata/) contains the Federal Register in XML from 2000 to the present. Please see FDsys at [www.fdsys.gov](http://www.fdsys.gov/) for access to the Federal Register in PDF and HTML formats.  
 
-##1.2.Legal Status & Authenticity of Federal Register files via Data.gov
+##1.2.Legal Status & Authenticity of Federal Register files via _Data.gov_
 
  
 
 **Q. What is the data set available for the Federal Register in XML?**
-
 **A.** Federal Register files in XML have been converted and simplified from the SGML rendition used for the printed publication. The Federal Register is available in XML starting with the year 2000, when GPO began composing Federal Register material in SGML. OFR/GPO plan to convert the remaining electronic data set for the _Federal Register_ (1994-1999) at a future date.
 
  
-
 **Q.  Are bulk data downloads of XML files offered on FDsys via Data.gov part of the official version of the _Federal Register_?**
-
- 
-
 **A.**  No, the XML-structured files offered for bulk download are not part of the official on-line format of the _Federal Register_. While GPO's XML files are based on the original source data submitted by Federal agencies, OFR markup, and GPO typesetting and composition markup in SGML, only the PDF and Text versions of _Federal Register_ content on GPO Access and FDsys have legal status as parts of the official online format of the _Federal Register_.  Additional development will be required before OFR/GPO can specify that XML files are a part of the official online edition of the _Federal Register_.  
-
  
 
 **Q.  Do OFR/GPO plan to include XML files as part of the official format of the Federal Register?**
-
- 
-
 **A.**  Yes. The current set of XML-structured material (minus graphics) is not yet characterized as part of the official online _Federal Register_ format because the underlying data used to create a viewable rendition of the material must be thoroughly scrutinized and tested. The XML-structured files are derived from SGML-tagged data and printing codes, which may produce anomalies in display.  For example, complex tabular material in XML files may not display as correctly composed objects equivalent to the tables that appear in the Text and PDF files.  Tabular material that displays in an ambiguous or distorted manner could affect the substantive meaning of regulations and other documents.  
-
- 
-
 Our goal is to clean up the XML data and develop associated style sheets to the point that the XML rendition can be characterized as a display format of the official online edition.  We are also developing the means to embed graphics in the files, so that an XML version may be deemed both official and complete.  The OFR will issue a _Federal Register Bulletin_ to alert users when the XML-structured files are ready to be included as part of the official online edition.  
 
-**Q.  What is the legal basis for making determinations about official status?**
 
+**Q.  What is the legal basis for making determinations about official status?**
 **A.**  The Federal Register Act established the Administrative Committee of the Federal Register (Administrative Committee or ACFR) as the regulatory body with authority to determine the format(s) of the official serial publication known as the _Federal Register _(44 U.S.C. Ch. 15). Under 1 CFR 5.10, the official formats approved by the ACFR include a paper edition, a microfiche edition, and an online edition.  OFR and GPO carry out ACFR regulations by developing appropriate means to display Federal Register material in the official formats.  
 
- 
 
-Q. When did the Federal Register first appear online?
-
+**Q. When did the Federal Register first appear online?**
 **A.** The official online edition dates to 1994 when Congress authorized an online edition in Public Law 103-40 (the Government Printing Office Electronic Information Enhancement Act of 1993; codified at 44 U.S.C. 4101).  
 
- 
 
-Q.  Are Federal Register XML bulk download files digitally signed?
-
+**Q.  Are Federal Register XML bulk download files digitally signed?**
 **A.** No, XML files available for download are not digitally signed.  They can be manipulated and enriched to operate in the various applications that users may devise. GPO is evaluating technology that could be used to digitally sign XML files for future official editions posted on FDsys.  Adding signed non-PDF files to FDsys would be an enhancement for FDsys users, but would not be used to restrict or adversely affect the XML bulk data downloads available to our customers.  
 
-**Q.  What does the term "digitally signed" mean?**
 
+**Q.  What does the term "digitally signed" mean?**
 **A**. Currently, GPO uses digital signature technology on PDF documents to add a visible Seal of Authenticity (a graphic of an eagle) to authenticated and certified documents. The technology allows GPO to secure data integrity, and provide users with assurance that the content is unchanged since it was disseminated by GPO. A signed and certified document also displays a blue ribbon icon to the left of the Seal of Authenticity and in the Signatures tab within Adobe Acrobat or Reader. When users print a document that has been signed and certified by GPO, the Seal of Authenticity will automatically print on the document, but the blue ribbon will not print.
 
-**Q. How reliable is the metadata and the underlying tagging in bulk data files?**
 
+**Q. How reliable is the metadata and the underlying tagging in bulk data files?**
 **A.**  The document markup and metadata found within bulk data files are generally reliable and complete.  However, there are variations in this underlying data due to inconsistencies in the composition and typesetting process.  As a result, some data-mining applications and user aids may not produce 100 per cent accurate results.  
 
-Q.  What is the legal status of Federal Register user aids?
 
+**Q.  What is the legal status of Federal Register user aids?**
 **A.** Federal Register user aids, including, finding aids, indexes, search tools, metadata associations, and tagging schemes are not part of the legal text of the _Federal Register_.  These ancillary features help users explore and extract data, but the official legal text stands on its own.  No person should form absolute legal conclusions based on search results, finding aids, metadata associations, extractions of data, and the like.  Ultimately, only the official text of the _Federal Register_ may be relied upon as evidence in a court of law.  
 
-**Q.  What is the authenticity of Federal Register bulk data files after they have been downloaded to another site?  **
 
+**Q.  What is the authenticity of Federal Register bulk data files after they have been downloaded to another site?  **
 **A.**   We cannot vouch for the authenticity of data that is not under OFR/GPO control. OFR and GPO are providing free access to Federal Register data via XML for display in various applications and mash-ups outside the FDsys domain.  The OFR/GPO partnership does not endorse third party applications, and does not evaluate how our original legal content is displayed on other sites.  Consumers should form their own conclusions as to whether the downloaded data can be relied upon within an application or mash-up.  An application may link to the official _Federal Register_ on FDsys to provide users with additional assurance.  
 
 **Q. Do OFR and GPO assert any control over downstream uses of bulk data?**
-
 **A.**  In general, there are no restrictions on re-use of information in Federal Register documents because U.S. Government works are not subject to copyright. OFR and GPO do not restrict downstream uses of Federal Register data, except that independent providers should be aware that only the OFR and GPO are entitled to represent that they are the providers of the official versions of the _Federal Register_ and related Federal Register publications.  
 
-
-Q. How can re-publishers indicate the source of Federal Register data?
-
+**Q. How can re-publishers indicate the source of Federal Register data?**
 **A.** Re-publishers of Federal Register data may cite FDsys and OFR/GPO as the source of their data, and they are free to characterize the quality of data as it appears on their site. But private sector re-publishers are prohibited from using the seal of the National Archives and Records Administration (NARA) or stylized Federal Register logos identified in NARA regulations (36 CFR part 1200) on their products because that would unlawfully misrepresent the legal status of the material, and could falsely identify  private organizations as entities of the Federal Government.
+
 
 #2.Schema Description
 

--- a/FR-XML_User-Guide.md
+++ b/FR-XML_User-Guide.md
@@ -224,7 +224,7 @@ The XML tags and their descriptions of the schema above are shown below:
 An abbreviated example of the overall section and structure is below:
 
  
-
+```
 <FEDREG>
 
   <VOL>65</VOL>
@@ -263,6 +263,7 @@ An abbreviated example of the overall section and structure is below:
   .
 
 </FEDREG>
+```
 
 ###2.2.1.XPath Examples
 
@@ -302,7 +303,7 @@ The XML tags and their descriptions of the schema above are shown below:
 An abbreviated example of the NEWPART section and structure is below:
 
 &nbsp;
-
+```
 <FEDREG>
    .
    .
@@ -321,6 +322,7 @@ An abbreviated example of the NEWPART section and structure is below:
     </PRESDOCS>
   </NEWPART>
 </FEDREG>
+```
 
 ##2.4.The Contents of Article
 
@@ -343,9 +345,8 @@ The contents of article tags are the ones that usually describe the majority of 
 The contents will roughly have the same structure
 
  
-
+```
 <FEDREG>
-
    .
    .
    .
@@ -383,7 +384,7 @@ The contents will roughly have the same structure
   .
   .
 </FEDREG>
-
+```
 &nbsp;
 
 ##2.5.PREAMBLE Tag
@@ -415,7 +416,7 @@ The XML tags and their descriptions of the schema above are shown below:
 An abbreviated example of the PREAMB section and structure is below:
 
 &nbsp;
-
+```
 <RULE>
 
   <PREAMB>
@@ -436,7 +437,7 @@ An abbreviated example of the PREAMB section and structure is below:
   <FRDOC>[FR Doc. E8-4768 Filed 3-7-08; 8:45 am]</FRDOC>
   <BILCOD>BILLING CODE 7590-01-P</BILCOD>
 </RULE>
-
+```
 &nbsp;
 
 ##2.6.SUPLINF Tag
@@ -458,7 +459,7 @@ The XML tags and their descriptions of the SUPLINF schema are shown below.
 An abbreviated example of the SUPLINF section and structure is below:
 
 &nbsp;
-
+```
 <RULE>
 ...
 <SUPLINF>
@@ -473,6 +474,7 @@ An abbreviated example of the SUPLINF section and structure is below:
   </SUPLINF>
 ...
 </RULE>
+```
 &nbsp;
 
 ##2.7.Presidential Documents
@@ -502,7 +504,7 @@ The XML tags and their descriptions of the schema above are shown below:
 An abbreviated example of the PRESDOCS section and structure is below:
 
 &nbsp;
-
+```
 <FEDREG>
 ...  
   <NEWPART>
@@ -533,9 +535,7 @@ An abbreviated example of the PRESDOCS section and structure is below:
   </NEWPART>
 ...
 </FEDREG>
-
-&nbsp;
-
+```
 &nbsp;
 
 #3.Resources Directory


### PR DESCRIPTION
@llaplant, could you take a look at the markdown-formatted user guides for FR and CFR? I simplified the formatting from the PDF a bit (and somewhat following the versions that @wbushey put together for Bills and Bill Summary). The word to md app that @benbalter created and mentioned was _very_ helpful.

May want to remove the `&nbsp;` that are throughout, but I liked having some extra separation in some places.

If they're good for you, go ahead and merge.
