### PR TITLE
Added missing space before heading of 1.1

### DIFF
--- a/Bills-Summary-XML-User-Guide.md
+++ b/Bills-Summary-XML-User-Guide.md
@@ -31,7 +31,7 @@ Data repository for Bill Summaries is available at
 <http://www.gpo.gov/fdsys/bulkdata/BILLSUM>.
 
 
-###1.1 Types of Bill Summaries
+### 1.1 Types of Bill Summaries
 
 Bill summaries are summaries of bills or resolutions, as well as other document types associated
 with the legislative history of a measure such as amendments, committee reports, conference


### PR DESCRIPTION
There was a missing space that made the `###` show instead of the actual heading formatting before section 1.1. Great work with this!